### PR TITLE
USWDS-Next: Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,77 @@
+<!---
+Step 1 - Title this PR with the following format:
+USWDS-Next: [Brief statement describing what this pull request does]
+eg: "USWDS-Next: Update dependencies"
+ -->
+
+# Summary
+
+_Provide a one or two sentence summary of the update that can be used in the changelog._
+<!--
+A successful summary is written in the past tense and includes:
+**A benefit statement.** A description of the update.
+See [USWDS release notes](https://github.com/uswds/uswds/releases) for examples.
+-->
+
+## Related issue
+
+Closes #_[issue_no]_
+<!--
+Every pull request should resolve an open issue.
+If no open issue exists, you can open one here:
+https://github.com/uswds/uswds/issues/new/choose.
+-->
+
+## Preview link
+
+Preview link:
+<!-- If available, provide a link to a demo of the solution in action. -->
+
+## Problem statement
+
+_Summarize the problem this PR solves in a clear and concise statement._
+<!--
+A successful problem statement conveys:
+1. The desired state,
+2. The actual state, and
+3. Consequences of remaining in the current state
+   (who does this affect and to what degree?)
+-->
+
+## Solution
+
+_Provide a summary of the solution this PR offers._
+<!--
+It can be helpful if we understand:
+1. What the solution is,
+2. Why this approach was chosen,
+3. How you implemented the change, and
+4. Possible limitations of this approach and alternate solution paths.
+-->
+
+## Major changes
+
+_For complex PRs, create a list of the significant updates made._
+
+## Testing and review
+
+_Share recommended methods for reviewing this change._
+<!--
+1. Describe the tests that you ran to verify your changes,
+2. Provide instructions to reproduce these tests, and
+3. Clarify the type of feedback you are looking for at this phase.
+-->
+
+<!--
+## Dependency updates
+
+| Dependency name              | Previous version | New version |
+| ---------------------------- | :--------------: | :---------: |
+| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
+| [New dependency example]     |        --        |   [3.0.1]   |
+| [Removed dependency example] |     [2.10.2]     |     --      |
+-->
+<!--
+For PRs that include dependency updates, uncomment this section and
+include a list of the changed dependencies and version numbers.
+-->


### PR DESCRIPTION
# Summary

Added a PR template to the uswds-next repo. 

> [!Note]
> Right now the template is pretty basic and similar to our other PR templates, but I expect this PR template will evolve as the repo does. For example, I could imagine adding sections for any component doc requirements we might develop. For now, I didn't speculate on what we might want and went with only the sections that felt solid. We should continue to revisit this PR template as we move forward.

> [!Note]
> This is based on the PR templates in the [uswds](https://github.com/uswds/uswds/blob/develop/.github/PULL_REQUEST_TEMPLATE.md), [uswds-site](https://github.com/uswds/uswds-site/blob/main/.github/PULL_REQUEST_TEMPLATE.md), and [uswds-compile](https://github.com/uswds/uswds-compile/blob/develop/.github/PULL_REQUEST_TEMPLATE.md) PR templates

## Related issue

Closes #34 

## Preview link
[PR template in preview mode](https://github.com/uswds/uswds-next/blob/823b322e1d6feadbbcca9c566d3eca8b94041b96/.github/PULL_REQUEST_TEMPLATE.md)

## Testing and review
- Confirm that the structure and content of the PR template makes sense for the repo
- Confirm that the PR template is in the [right location](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template) in the `.github` directory
