### PR TITLE
Web-components: Update vulnerable `wait-on` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "storybook": "^8.2.7",
         "vite": "^5.3.5",
         "vitest": "^1.6.0",
-        "wait-on": "^7.2.0"
+        "wait-on": "^7.1.0"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.20.0"
@@ -5335,15 +5335,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/babel-core": {
@@ -12985,13 +12983,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/psl": {
       "version": "1.9.0",
       "dev": true,
@@ -15233,13 +15224,12 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.1.0.tgz",
+      "integrity": "sha512-U7TF/OYYzAg+OoiT/B8opvN48UHt0QYMi4aD3PjRFpybQ+o6czQF8Ig3SKCCMJdxpBrCalIJ4O00FBof27Fu9Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.1",
+        "axios": "^0.27.2",
         "joi": "^17.11.0",
         "lodash": "^4.17.21",
         "minimist": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "storybook": "^8.2.7",
     "vite": "^5.3.5",
     "vitest": "^1.6.0",
-    "wait-on": "^7.2.0"
+    "wait-on": "^7.1.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.20.0"


### PR DESCRIPTION
# Summary

Updated the `wait-on` dependency to fix a high-severity vulnerability

## Testing and review

`wait-on` is a dependency used in the storybook tests, so as long as the tests pass before and after updating the dependency, it should be good to go.

## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| wait-on |     7.1.0      |   7.2.0   |