### PR TITLE
Web components: Remove references to old repo name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!---
 Step 1 - Title this PR with the following format:
-Web components - : [Brief statement describing what this pull request does]
+Web components : [Brief statement describing what this pull request does]
 eg: "Web components: Update dependencies"
  -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!---
 Step 1 - Title this PR with the following format:
-USWDS-Next: [Brief statement describing what this pull request does]
-eg: "USWDS-Next: Update dependencies"
+Web components - : [Brief statement describing what this pull request does]
+eg: "Web components: Update dependencies"
  -->
 
 # Summary
@@ -72,7 +72,7 @@ _Share recommended methods for reviewing this change._
 ## Dependency updates
 
 | Dependency name              | Previous version | New version |
-| ---------------------------- | :--------------: | :---------: |
+| :---------------------------- | :--------------: | :---------: |
 | [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
 | [New dependency example]     |        --        |   [3.0.1]   |
 | [Removed dependency example] |     [2.10.2]     |     --      |

--- a/.storybook/UswdsTheme.js
+++ b/.storybook/UswdsTheme.js
@@ -2,7 +2,7 @@ import { create } from "@storybook/theming/create";
 
 export default create({
   base: "light",
-  brandTitle: "USWDS Next",
+  brandTitle: "USWDS Web components",
   fontBase:
     '"Public Sans Web", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
   colorPrimary: "#4a77b4",


### PR DESCRIPTION

# Summary

Removes references to `next`.


## Related issue

Closes #61.

## Problem statement

There were still references to old repo name.

## Solution

For accuracy updated to `web components` instead of `next`.

<!--
It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->

## Testing and review

Pull request template and  Storybook name should be USWDS web components.

<!--
## Dependency updates

| Dependency name              | Previous version | New version |
| ---------------------------- | :--------------: | :---------: |
| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
| [New dependency example]     |        --        |   [3.0.1]   |
| [Removed dependency example] |     [2.10.2]     |     --      |
-->
<!--
For PRs that include dependency updates, uncomment this section and
include a list of the changed dependencies and version numbers.
-->
