### PR TITLE
USWDS Web-Components - POAM: January '25

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -187,6 +187,29 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/index.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "UsaLink",
+          "declaration": {
+            "name": "UsaLink",
+            "module": "src/components/index.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "UsaBanner",
+          "declaration": {
+            "name": "UsaBanner",
+            "module": "src/components/index.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "storybook-static/assets/Color-ERTF36HU-GcHtjzx3.js",
       "declarations": [
         {
@@ -6725,71 +6748,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/index.js",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "UsaLink",
-          "declaration": {
-            "name": "UsaLink",
-            "module": "src/components/index.js"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "UsaBanner",
-          "declaration": {
-            "name": "UsaBanner",
-            "module": "src/components/index.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-preview/globals.js",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "_",
-          "type": {
-            "text": "object"
-          },
-          "default": "{ \"@storybook/global\": \"__STORYBOOK_MODULE_GLOBAL__\", \"storybook/internal/channels\": \"__STORYBOOK_MODULE_CHANNELS__\", \"@storybook/channels\": \"__STORYBOOK_MODULE_CHANNELS__\", \"@storybook/core/channels\": \"__STORYBOOK_MODULE_CHANNELS__\", \"storybook/internal/client-logger\": \"__STORYBOOK_MODULE_CLIENT_LOGGER__\", \"@storybook/client-logger\": \"__STORYBOOK_MODULE_CLIENT_LOGGER__\", \"@storybook/core/client-logger\": \"__STORYBOOK_MODULE_CLIENT_LOGGER__\", \"storybook/internal/core-events\": \"__STORYBOOK_MODULE_CORE_EVENTS__\", \"@storybook/core-events\": \"__STORYBOOK_MODULE_CORE_EVENTS__\", \"@storybook/core/core-events\": \"__STORYBOOK_MODULE_CORE_EVENTS__\", \"storybook/internal/preview-errors\": \"__STORYBOOK_MODULE_CORE_EVENTS_PREVIEW_ERRORS__\", \"@storybook/core-events/preview-errors\": \"__STORYBOOK_MODULE_CORE_EVENTS_PREVIEW_ERRORS__\", \"@storybook/core/preview-errors\": \"__STORYBOOK_MODULE_CORE_EVENTS_PREVIEW_ERRORS__\", \"storybook/internal/preview-api\": \"__STORYBOOK_MODULE_PREVIEW_API__\", \"@storybook/preview-api\": \"__STORYBOOK_MODULE_PREVIEW_API__\", \"@storybook/core/preview-api\": \"__STORYBOOK_MODULE_PREVIEW_API__\", \"storybook/internal/types\": \"__STORYBOOK_MODULE_TYPES__\", \"@storybook/types\": \"__STORYBOOK_MODULE_TYPES__\", \"@storybook/core/types\": \"__STORYBOOK_MODULE_TYPES__\" }"
-        },
-        {
-          "kind": "variable",
-          "name": "O"
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "globalPackages",
-          "declaration": {
-            "name": "O",
-            "module": "storybook-static/sb-preview/globals.js"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "globalsNameReferenceMap",
-          "declaration": {
-            "name": "_",
-            "module": "storybook-static/sb-preview/globals.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-preview/runtime.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
       "path": "storybook-static/sb-manager/globals-module-info.js",
       "declarations": [
         {
@@ -6858,73 +6816,43 @@
     },
     {
       "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/a11y-10/manager-bundle.js",
-      "declarations": [],
-      "exports": []
+      "path": "storybook-static/sb-preview/globals.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "_",
+          "type": {
+            "text": "object"
+          },
+          "default": "{ \"@storybook/global\": \"__STORYBOOK_MODULE_GLOBAL__\", \"storybook/internal/channels\": \"__STORYBOOK_MODULE_CHANNELS__\", \"@storybook/channels\": \"__STORYBOOK_MODULE_CHANNELS__\", \"@storybook/core/channels\": \"__STORYBOOK_MODULE_CHANNELS__\", \"storybook/internal/client-logger\": \"__STORYBOOK_MODULE_CLIENT_LOGGER__\", \"@storybook/client-logger\": \"__STORYBOOK_MODULE_CLIENT_LOGGER__\", \"@storybook/core/client-logger\": \"__STORYBOOK_MODULE_CLIENT_LOGGER__\", \"storybook/internal/core-events\": \"__STORYBOOK_MODULE_CORE_EVENTS__\", \"@storybook/core-events\": \"__STORYBOOK_MODULE_CORE_EVENTS__\", \"@storybook/core/core-events\": \"__STORYBOOK_MODULE_CORE_EVENTS__\", \"storybook/internal/preview-errors\": \"__STORYBOOK_MODULE_CORE_EVENTS_PREVIEW_ERRORS__\", \"@storybook/core-events/preview-errors\": \"__STORYBOOK_MODULE_CORE_EVENTS_PREVIEW_ERRORS__\", \"@storybook/core/preview-errors\": \"__STORYBOOK_MODULE_CORE_EVENTS_PREVIEW_ERRORS__\", \"storybook/internal/preview-api\": \"__STORYBOOK_MODULE_PREVIEW_API__\", \"@storybook/preview-api\": \"__STORYBOOK_MODULE_PREVIEW_API__\", \"@storybook/core/preview-api\": \"__STORYBOOK_MODULE_PREVIEW_API__\", \"storybook/internal/types\": \"__STORYBOOK_MODULE_TYPES__\", \"@storybook/types\": \"__STORYBOOK_MODULE_TYPES__\", \"@storybook/core/types\": \"__STORYBOOK_MODULE_TYPES__\" }"
+        },
+        {
+          "kind": "variable",
+          "name": "O"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "globalPackages",
+          "declaration": {
+            "name": "O",
+            "module": "storybook-static/sb-preview/globals.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "globalsNameReferenceMap",
+          "declaration": {
+            "name": "_",
+            "module": "storybook-static/sb-preview/globals.js"
+          }
+        }
+      ]
     },
     {
       "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/chromatic-com-storybook-9/manager-bundle.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/essentials-actions-3/manager-bundle.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/essentials-backgrounds-4/manager-bundle.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/essentials-controls-2/manager-bundle.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/essentials-measure-7/manager-bundle.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/essentials-outline-8/manager-bundle.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/links-1/manager-bundle.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/storybook-11/manager-bundle.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/essentials-viewport-5/manager-bundle.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/essentials-toolbars-6/manager-bundle.js",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "storybook-static/sb-addons/storybook-core-core-server-presets-0/common-manager-bundle.js",
+      "path": "storybook-static/sb-preview/runtime.js",
       "declarations": [],
       "exports": []
     },
@@ -7414,6 +7342,78 @@
     {
       "kind": "javascript-module",
       "path": "src/components/usa-link/usa-link.spec.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/essentials-actions-3/manager-bundle.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/essentials-backgrounds-4/manager-bundle.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/essentials-controls-2/manager-bundle.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/a11y-10/manager-bundle.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/chromatic-com-storybook-9/manager-bundle.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/essentials-outline-8/manager-bundle.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/essentials-measure-7/manager-bundle.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/essentials-toolbars-6/manager-bundle.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/essentials-viewport-5/manager-bundle.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/links-1/manager-bundle.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/storybook-core-core-server-presets-0/common-manager-bundle.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "storybook-static/sb-addons/storybook-11/manager-bundle.js",
       "declarations": [],
       "exports": []
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@uswds/web-components",
       "version": "1.0.0-alpha",
       "dependencies": {
-        "@uswds/uswds": "^3.10.0",
+        "@uswds/uswds": "^3.11.0",
         "lit": "^3.2.1",
-        "sass": "^1.83.0"
+        "sass": "^1.83.1"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^1.8.0",
@@ -42,7 +42,7 @@
         "wait-on": "^7.2.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.28.1"
+        "@rollup/rollup-linux-x64-gnu": "^4.30.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2136,9 +2136,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
-      "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
+      "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
       "cpu": [
         "x64"
       ],
@@ -3641,9 +3641,9 @@
       "license": "MIT"
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.10.0.tgz",
-      "integrity": "sha512-LWFTQzp4e3kqtnD/Wsyfx9uGTkn5GEpzhscNWJMIsdWBGKtiu96QT99oRJUmcsB6HbGhR0Th0FtlK/Zzx2WghA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.11.0.tgz",
+      "integrity": "sha512-ze0MNXaZhgXLyNICpclm5g4pOGyU4/FE0DQTP5G19mHWB914vrCJvOxyTo2n1qGVMVwJtf6MtpBCnghAC8WaZA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "receptor": "1.0.0",
@@ -10878,9 +10878,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.83.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.0.tgz",
-      "integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
+      "version": "1.83.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.1.tgz",
+      "integrity": "sha512-EVJbDaEs4Rr3F0glJzFSOvtg2/oy2V/YrGFPqPY24UqcLDWcI9ZY5sN+qyO3c/QCZwzgfirvhXvINiJCE/OLcA==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "pages": "npm run storybook:build && cp -r storybook-static _site"
   },
   "dependencies": {
-    "@uswds/uswds": "^3.10.0",
+    "@uswds/uswds": "^3.11.0",
     "lit": "^3.2.1",
-    "sass": "^1.83.0"
+    "sass": "^1.83.1"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.8.0",
@@ -73,6 +73,6 @@
     "wait-on": "^7.2.0"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.28.1"
+    "@rollup/rollup-linux-x64-gnu": "^4.30.1"
   }
 }


### PR DESCRIPTION
# Summary

Dependency updates for January 2025

## Breaking change

This is not a breaking change.

## Related issue

[USWDS - POAM: Jan '25](https://github.com/uswds/uswds-team/issues/462)

## Preview link

[Preview link →](https://federalist-ab6c0bdb-eccd-4b26-bb5f-b0154661e999.sites.pages.cloud.gov/preview/uswds/web-components/cm-poam-jan-25/)

## Major changes

- Updated to USWDS 3.11.0

## Dependency updates

**Before:**

```jsx
found 0 vulnerabilities
```

| **Dependency Name** | **Old Version** | **New Version** |
| --- | --- | --- |
| **@rollup/rollup-linux-x64-gnu** | **^4.28.1** | **^4.30.1** |
| **@uswds/uswds** | **^3.10.0** | **^3.11.0** |
| **sass** | **^1.83.0** | **^1.83.1** |

## Testing and review

1. Confirm there are no installation errors
2. Confirm there are no build errors
3. Confirm there are no test errors
5. Storybook builds without error
6. Run `npm start` and confirm the stroybook previews display correctly.