### PR TITLE
USWDS [Elements/4.0] - Bump node version in GH actions

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: 20
           cache: "npm"
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: 20
           cache: "npm"
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
En route to getting builds green again, the storybook test action is failing due to the node version the action is running on. This just bumps the version to 20 for both actions that run node.