### PR TITLE
Web components: match usa-banner styles to current core styles

### DIFF
--- a/src/components/usa-banner/index.ts
+++ b/src/components/usa-banner/index.ts
@@ -68,7 +68,7 @@ export class UsaBanner extends LitElement {
         banner: {
           label: "Official website of the United States government",
           text: "An official website of the United States government",
-          action: "Here's how you know",
+          action: "Here’s how you know",
         },
         domain: {
           heading: "Official websites use",
@@ -135,6 +135,7 @@ export class UsaBanner extends LitElement {
         role="img"
         alt=""
         aria-hidden="true"
+        fetchpriority="low"
       />
       <div class="usa-media-block__body">
         <p>
@@ -171,6 +172,7 @@ export class UsaBanner extends LitElement {
         role="img"
         alt=""
         aria-hidden="true"
+        fetchpriority="low"
       />
       <div class="usa-media-block__body">
         <p>
@@ -217,9 +219,12 @@ export class UsaBanner extends LitElement {
                 <p class="header-text">
                   <slot name="banner-text">${banner.text}</slot>
                 </p>
-                <p class="header-action">
-                  <slot name="banner-action">${banner.action}</slot>
-                </p>
+                <!-- 
+                  Since the header-action text below is underlined, the slot and p 
+                  need to be on the same line to avoid one extra space of underline 
+                  before the expand icon.
+                -->
+                <p class="header-action"><slot name="banner-action">${banner.action}</slot></p>
               </div>
               <button
                 type="button"

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -19,7 +19,7 @@ export const bannerStyles: CSSResultGroup = [
       --usa-banner-font-size-xs: 0.75rem;
       --usa-banner-font-size-sm: 0.875rem;
       --usa-banner-font-size-base: 0.94rem;
-      --usa-banner-line-height-base: 1.5;
+      --usa-banner-line-height-base: 1.6;
       --usa-banner-line-height-sm: 1.2;
 
       --usa-spacing-05: 0.25rem;
@@ -81,6 +81,7 @@ export const bannerStyles: CSSResultGroup = [
         auto-fill,
         minmax(min(100%, calc(var(--usa-breakpoint-tablet) / 2)), 1fr)
       );
+      gap: var(--usa-spacing-3);
     }
     
     .grid-col-auto {
@@ -95,7 +96,7 @@ export const bannerStyles: CSSResultGroup = [
     }
     
     @media (min-width: 40em) {
-      .tablet\\:grid-col-fill {
+      .tablet\\:grid-col-auto {
         flex: 0 1 auto;
         width: auto;
         max-width: 100%;
@@ -115,6 +116,7 @@ export const bannerStyles: CSSResultGroup = [
 
     .content {
       max-width: var(--usa-banner-max-width);
+      line-height: var(--usa-banner-line-height-base);
       margin-left: auto;
       margin-right: auto;
       padding-left: var(--usa-spacing-1);
@@ -129,8 +131,17 @@ export const bannerStyles: CSSResultGroup = [
 
     @media (min-width: 40em) {
       .content {
-        padding-left: var(--usa-spacing-2);
-        padding-right: var(--usa-spacing-2);
+        padding-left: var(--usa-spacing-1);
+        padding-right: var(--usa-spacing-1);
+        padding-top: var(--usa-spacing-3);
+        padding-bottom: var(--usa-spacing-3);
+      }
+    } 
+      
+    @media (min-width: 64em) {
+      .content {
+        padding-left: var(--usa-spacing-4);
+        padding-right: var(--usa-spacing-4);
         padding-top: var(--usa-spacing-3);
         padding-bottom: var(--usa-spacing-3);
       }
@@ -154,6 +165,11 @@ export const bannerStyles: CSSResultGroup = [
     @media (min-width: 40em) {
       .inner {
         align-items: center;
+      }
+    }
+    
+    @media (min-width: 64em) {
+      .inner {
         padding-left: var(--usa-spacing-4);
         padding-right: var(--usa-spacing-4);
       }

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -90,7 +90,6 @@ export const bannerStyles: CSSResultGroup = [
         auto-fill,
         minmax(min(100%, calc(var(--usa-breakpoint-tablet) / 2)), 1fr)
       );
-      gap: var(--usa-spacing-4);
     }
     
     .grid-col-auto {
@@ -129,14 +128,11 @@ export const bannerStyles: CSSResultGroup = [
       margin-right: auto;
       padding-left: var(--usa-spacing-2);
       padding-right: var(--usa-spacing-2);
+      padding-bottom: var(--usa-spacing-3);
+      padding-top: var(--usa-spacing-3);
       background-color: var(--usa-color-transparent);
       font-size: var(--usa-banner-font-size-base);
       overflow: hidden;
-      padding-bottom: var(--usa-spacing-2);
-      padding-left: calc(
-        var(--usa-site-margins-mobile-width) - var(--usa-spacing-1)
-      );
-      padding-top: var(--usa-spacing-05);
       width: 100%;
     }
 

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -48,7 +48,7 @@ export const bannerStyles: CSSResultGroup = [
       --usa-icon-expand-more: url("/src/shared/icons/expand_more.svg");
       --usa-icon-expand-less: url("/src/shared/icons/expand_less.svg");
       --usa-icon-close: url("/src/shared/icons/close.svg");
-      --usa-icon-lock: url("/src/shared/icons/lock.svg");
+      --usa-icon-lock: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='52' height='64' viewBox='0 0 52 64' class='usa-banner__lock-image' role='img' aria-labelledby='banner-lock-description-default' focusable='false'%3E%3Ctitle id='banner-lock-title-default'%3ELock%3C/title%3E%3Cdesc id='banner-lock-description-default'%3ELocked padlock icon%3C/desc%3E%3Cpath fill='%23000000' fill-rule='evenodd' d='M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z'%3E%3C/path%3E%3C/svg%3E");
     }
 
     * {
@@ -101,7 +101,7 @@ export const bannerStyles: CSSResultGroup = [
 
     @media (min-width: 64em) {
       section .grid-row {
-        gap: calc(var(--usa-spacing-05) / 2));
+        gap: calc(var(--usa-spacing-05) / 2);
       }
     }
 
@@ -470,7 +470,7 @@ export const bannerStyles: CSSResultGroup = [
     .guidance {
       display: flex;
       align-items: flex-start;
-      max-width: 61ex;
+      max-width: 62ex;
       padding-block-start: var(--usa-spacing-2);
     }
 
@@ -510,7 +510,6 @@ export const bannerStyles: CSSResultGroup = [
       mask-position: center;
       mask-repeat: no-repeat;
       mask-size: cover;
-      vertical-align: middle;
       width: 1.21875ex;
     }
 

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -402,10 +402,10 @@ export const bannerStyles: CSSResultGroup = [
         right: 0;
         content: "";
         display: block;
-        width: 1.5rem;
-        height: 1.5rem;
+        width: var(--usa-size-touch-target);
+        height: var(--usa-size-touch-target);
         background-color: var(--usa-color-blue-60v);
-        mask-size: contain;
+        mask-size: 1.5rem 1.5rem;
         mask-repeat: no-repeat;
         mask-position: center;
         background-image: var(--usa-icon-close);

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -460,6 +460,12 @@ export const bannerStyles: CSSResultGroup = [
       max-width: 61ex;
       padding-block-start: var(--usa-spacing-2);
     }
+    
+    @media (max-width: 39.99em) {
+      .guidance {
+        padding-inline-end: .75rem;
+      }
+    }
 
     @media (min-width: 40em) {
       .guidance {

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -81,7 +81,12 @@ export const bannerStyles: CSSResultGroup = [
         auto-fill,
         minmax(min(100%, calc(var(--usa-breakpoint-tablet) / 2)), 1fr)
       );
-      gap: var(--usa-spacing-3);
+    }
+    
+    @media (min-width: 40em) {
+      section .grid-row {
+        gap: var(--usa-spacing-3);
+      }
     }
     
     .grid-col-auto {

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -56,9 +56,9 @@ export const bannerStyles: CSSResultGroup = [
     }
 
     section {
-      font-family: var(--theme-banner-font-family);
-      box-sizing: border-box;
       background-color: var(--theme-banner-background-color);
+      box-sizing: border-box;
+      font-family: var(--theme-banner-font-family);
       font-size: var(--usa-banner-font-size-xs);
     }
 
@@ -98,7 +98,7 @@ export const bannerStyles: CSSResultGroup = [
         gap: var(--usa-spacing-2);
       }
     }
-    
+
     @media (min-width: 64em) {
       section .grid-row {
         gap: calc(var(--usa-spacing-05) / 2));
@@ -111,23 +111,23 @@ export const bannerStyles: CSSResultGroup = [
 
     .grid-col-fill {
       flex: 1 1 0;
-      width: auto;
       max-width: 100%;
       min-width: 1px;
+      width: auto;
     }
 
     @media (min-width: 40em) {
       .tablet\\:grid-col-auto {
         flex: 0 1 auto;
-        width: auto;
         max-width: 100%;
+        width: auto;
       }
     }
 
     section .tablet\\:grid-col-6 {
       flex: 0 0 auto;
-      width: 100%;
       gap: var(--usa-spacing-1);
+      width: 100%;
     }
 
     header,
@@ -136,15 +136,15 @@ export const bannerStyles: CSSResultGroup = [
     }
 
     .content {
-      max-width: var(--usa-banner-max-width);
+      background-color: var(--usa-color-transparent);
+      font-size: var(--usa-banner-font-size-base);
       line-height: var(--usa-banner-line-height-base);
       margin-inline: auto;
+      max-width: var(--usa-banner-max-width);
+      overflow: hidden;
       padding-block-end: var(--usa-spacing-2);
       padding-block-start: var(--usa-spacing-05);
       padding-inline: var(--usa-spacing-1);
-      background-color: var(--usa-color-transparent);
-      font-size: var(--usa-banner-font-size-base);
-      overflow: hidden;
       width: 100%;
     }
 
@@ -165,13 +165,13 @@ export const bannerStyles: CSSResultGroup = [
     }
 
     .inner {
-      padding-inline-start: var(--usa-spacing-2);
-      padding-inline-end: 0;
-      max-width: var(--usa-banner-max-width);
-      margin-inline: auto;
+      align-items: flex-start;
       display: flex;
       flex-wrap: nowrap;
-      align-items: flex-start;
+      margin-inline: auto;
+      max-width: var(--usa-banner-max-width);
+      padding-inline-end: 0;
+      padding-inline-start: var(--usa-spacing-2);
     }
 
     @media (min-width: 40em) {
@@ -187,44 +187,44 @@ export const bannerStyles: CSSResultGroup = [
     }
 
     header {
-      padding-block: var(--usa-spacing-1);
       font-size: var(--usa-banner-font-size-xs);
       font-weight: 400;
       min-height: var(--usa-size-touch-target);
+      padding-block: var(--usa-spacing-1);
       position: relative;
     }
 
     @media (min-width: 40em) {
       header {
-        padding-block: var(--usa-spacing-05);
         min-height: 0;
+        padding-block: var(--usa-spacing-05);
       }
     }
 
     .header-text {
-      margin-block: 0;
       font-size: var(--usa-banner-font-size-xs);
       line-height: var(--usa-banner-line-height-sm);
+      margin-block: 0;
     }
 
     .header-flag {
       float: left;
       margin-inline-end: var(--usa-spacing-1);
-      width: var(--usa-spacing-2);
       padding-block-start: 0;
+      width: var(--usa-spacing-2);
     }
 
     .header-action {
-      color: var(--usa-banner-link-color);
-      text-decoration: underline;
       background: none;
       border: none;
-      padding: 0;
-      font: inherit;
+      color: var(--usa-banner-link-color);
       cursor: pointer;
+      font: inherit;
       line-height: var(--usa-banner-line-height-sm);
       margin-block-end: 0;
       margin-block-start: 2px;
+      padding: 0;
+      text-decoration: underline;
     }
 
     .header-action:hover {
@@ -232,17 +232,17 @@ export const bannerStyles: CSSResultGroup = [
     }
 
     .header-action::after {
+      background-color: currentColor;
+      background-image: var(--usa-icon-expand-more);
       content: "";
       display: inline-block;
-      width: 1rem;
       height: 1rem;
-      background-color: currentColor;
-      mask-size: 1rem 1rem;
-      mask-repeat: no-repeat;
-      mask-position: center;
-      background-image: var(--usa-icon-expand-more);
       mask-image: var(--usa-icon-expand-more);
+      mask-position: center;
+      mask-repeat: no-repeat;
+      mask-size: 1rem 1rem;
       vertical-align: middle;
+      width: 1rem;
     }
 
     .expanded .header-action {

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -80,6 +80,12 @@ export const bannerStyles: CSSResultGroup = [
 
     section .grid-row {
       display: grid;
+      /**
+       * This creates a responsive grid where:
+       * - Columns auto-fit based on available space
+       * - Each column has a minimum width that's the smaller of 100% or half the tablet breakpoint (20rem)
+       * - Columns can grow to fill remaining space (1fr)
+       */
       grid-template-columns: repeat(
         auto-fit,
         minmax(min(100%, calc(var(--usa-breakpoint-tablet) / 2)), 1fr)
@@ -97,7 +103,7 @@ export const bannerStyles: CSSResultGroup = [
     }
 
     .grid-col-fill {
-      flex: 1 1 0%;
+      flex: 1 1 0;
       width: auto;
       max-width: 100%;
       min-width: 1px;
@@ -125,12 +131,10 @@ export const bannerStyles: CSSResultGroup = [
     .content {
       max-width: var(--usa-banner-max-width);
       line-height: var(--usa-banner-line-height-base);
-      margin-inline-start: auto;
-      margin-inline-end: auto;
-      padding-inline-start: var(--usa-spacing-1);
-      padding-inline-end: var(--usa-spacing-1);
+      margin-inline: auto;
       padding-block-end: var(--usa-spacing-2);
       padding-block-start: var(--usa-spacing-05);
+      padding-inline: var(--usa-spacing-1);
       background-color: var(--usa-color-transparent);
       font-size: var(--usa-banner-font-size-base);
       overflow: hidden;
@@ -139,19 +143,13 @@ export const bannerStyles: CSSResultGroup = [
 
     @media (min-width: 40em) {
       .content {
-        padding-inline-start: var(--usa-spacing-1);
-        padding-inline-end: var(--usa-spacing-1);
-        padding-block-start: var(--usa-spacing-3);
-        padding-block-end: var(--usa-spacing-3);
+        padding-block: var(--usa-spacing-3);
       }
     }
 
     @media (min-width: 64em) {
       .content {
-        padding-inline-start: var(--usa-spacing-4);
-        padding-inline-end: var(--usa-spacing-4);
-        padding-block-start: var(--usa-spacing-3);
-        padding-block-end: var(--usa-spacing-3);
+        padding-inline: var(--usa-spacing-4);
       }
     }
 
@@ -163,8 +161,7 @@ export const bannerStyles: CSSResultGroup = [
       padding-inline-start: var(--usa-spacing-2);
       padding-inline-end: 0;
       max-width: var(--usa-banner-max-width);
-      margin-inline-start: auto;
-      margin-inline-end: auto;
+      margin-inline: auto;
       display: flex;
       flex-wrap: nowrap;
       align-items: flex-start;
@@ -178,14 +175,12 @@ export const bannerStyles: CSSResultGroup = [
 
     @media (min-width: 64em) {
       .inner {
-        padding-inline-start: var(--usa-spacing-4);
-        padding-inline-end: var(--usa-spacing-4);
+        padding-inline: var(--usa-spacing-4);
       }
     }
 
     header {
-      padding-block-start: var(--usa-spacing-1);
-      padding-block-end: var(--usa-spacing-1);
+      padding-block: var(--usa-spacing-1);
       font-size: var(--usa-banner-font-size-xs);
       font-weight: 400;
       min-height: var(--usa-size-touch-target);
@@ -194,15 +189,13 @@ export const bannerStyles: CSSResultGroup = [
 
     @media (min-width: 40em) {
       header {
-        padding-block-start: var(--usa-spacing-05);
-        padding-block-end: var(--usa-spacing-05);
+        padding-block: var(--usa-spacing-05);
         min-height: 0;
       }
     }
 
     .header-text {
-      margin-block-start: 0;
-      margin-block-end: 0;
+      margin-block: 0;
       font-size: var(--usa-banner-font-size-xs);
       line-height: var(--usa-banner-line-height-sm);
     }
@@ -212,13 +205,6 @@ export const bannerStyles: CSSResultGroup = [
       margin-inline-end: var(--usa-spacing-1);
       width: var(--usa-spacing-2);
       padding-block-start: 0;
-    }
-
-    @media (min-width: 40em) {
-      .header-flag {
-        margin-inline-end: var(--usa-spacing-1);
-        padding-block-start: 0;
-      }
     }
 
     .header-action {
@@ -313,7 +299,6 @@ export const bannerStyles: CSSResultGroup = [
       top: 0;
       bottom: 0;
       color: var(--theme-banner-link-color);
-      text-decoration: underline;
       display: block;
       font-size: var(--usa-banner-font-size-xs);
       height: auto;

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -16,11 +16,20 @@ export const bannerStyles: CSSResultGroup = [
       --usa-banner-link-color: var(--usa-color-blue-60v, #005ea2);
       --usa-banner-link-hover-color: #1a4480;
       --usa-banner-max-width: 1200px;
-      --usa-banner-font-size-xs: 0.75rem;
+      
+      /**
+       * The core value is set to 0.8rem, which results in a font size of 12.8px.
+       * Is subpixel rounding ok or should this be 0.75rem (12px)? 
+       */
+      --usa-banner-font-size-xs: 0.8rem; 
       --usa-banner-font-size-sm: 0.875rem;
       --usa-banner-font-size-base: 1rem;
       --usa-banner-line-height-base: 1.5;
-      --usa-banner-line-height-sm: 1.4;
+      /**
+       * The core value is set to 1.1, which results in a line height of 14.08.
+       * Is subpixel rounding ok to retain parity? 
+       */
+      --usa-banner-line-height-sm: 1.1;
 
       --usa-spacing-05: 0.25rem;
       --usa-spacing-1: 0.5rem;
@@ -83,6 +92,25 @@ export const bannerStyles: CSSResultGroup = [
       );
       gap: var(--usa-spacing-4);
     }
+    
+    .grid-col-auto {
+      flex: 0 1 auto;
+    }
+    
+    .grid-col-fill {
+      flex: 1 1 0%;
+      width: auto;
+      max-width: 100%;
+      min-width: 1px;
+    }
+    
+    @media (min-width: 40em) {
+      .tablet\\:grid-col-fill {
+        flex: 0 1 auto;
+        width: auto;
+        max-width: 100%;
+      }
+    }
 
     section .tablet\\:grid-col-6 {
       flex: 0 0 auto;
@@ -127,26 +155,27 @@ export const bannerStyles: CSSResultGroup = [
 
     .inner {
       padding-left: var(--usa-spacing-2);
-      padding-right: var(--usa-spacing-2);
+      padding-right: 0;
       max-width: var(--usa-banner-max-width);
       margin-left: auto;
       margin-right: auto;
       display: flex;
       flex-wrap: nowrap;
       align-items: flex-start;
-      padding-right: 0;
     }
 
     @media (min-width: 40em) {
       .inner {
         align-items: center;
+        padding-left: var(--usa-spacing-4);
+        padding-right: var(--usa-spacing-4);
       }
     }
 
     header {
       padding-top: var(--usa-spacing-1);
       padding-bottom: var(--usa-spacing-1);
-      font-size: var(--usa-banner-font-size-sm);
+      font-size: var(--usa-banner-font-size-xs);
       font-weight: 400;
       min-height: var(--usa-size-touch-target);
       position: relative;
@@ -163,7 +192,7 @@ export const bannerStyles: CSSResultGroup = [
     .header-text {
       margin-top: 0;
       margin-bottom: 0;
-      font-size: var(--usa-banner-font-size-sm);
+      font-size: var(--usa-banner-font-size-xs);
       line-height: var(--usa-banner-line-height-sm);
     }
 
@@ -171,7 +200,7 @@ export const bannerStyles: CSSResultGroup = [
       float: left;
       margin-right: var(--usa-spacing-1);
       width: var(--usa-spacing-2);
-      padding-top: 3px;
+      padding-top: 0;
     }
 
     @media (min-width: 40em) {
@@ -201,15 +230,15 @@ export const bannerStyles: CSSResultGroup = [
     .header-action::after {
       content: "";
       display: inline-block;
-      width: 0.5rem;
-      height: 0.5rem;
-      margin-left: 0.25rem;
+      width: 1rem;
+      height: 1rem;
       background-color: currentColor;
-      mask-size: contain;
+      mask-size: 1rem 1rem;
       mask-repeat: no-repeat;
       mask-position: center;
       background-image: var(--usa-icon-expand-more);
       mask-image: var(--usa-icon-expand-more);
+      vertical-align: middle;
     }
 
     .expanded .header-action {
@@ -275,7 +304,7 @@ export const bannerStyles: CSSResultGroup = [
       color: var(--theme-banner-link-color);
       text-decoration: underline;
       display: block;
-      font-size: var(--usa-banner-font-size-sm);
+      font-size: var(--usa-banner-font-size-xs);
       height: auto;
       line-height: var(--usa-banner-line-height-sm);
       padding-top: 0;
@@ -319,7 +348,7 @@ export const bannerStyles: CSSResultGroup = [
         mask-repeat: no-repeat;
         mask-position: center;
         position: absolute;
-        top: 3px;
+        top: 0;
         right: -16px;
         background-image: var(--usa-icon-expand-more);
         mask-image: var(--usa-icon-expand-more);

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -15,7 +15,7 @@ export const bannerStyles: CSSResultGroup = [
         Helvetica, Arial, sans-serif;
       --usa-banner-link-color: var(--usa-color-blue-60v, #005ea2);
       --usa-banner-link-hover-color: #1a4480;
-      --usa-banner-max-width: 1200px;
+      --usa-banner-max-width: var(--usa-breakpoint-desktop);
       --usa-banner-font-size-xs: 0.75rem;
       --usa-banner-font-size-sm: 0.875rem;
       --usa-banner-font-size-base: 0.94rem;
@@ -36,6 +36,7 @@ export const bannerStyles: CSSResultGroup = [
       --usa-site-margins-width: 2rem;
 
       --usa-breakpoint-tablet: 40rem;
+      --usa-breakpoint-desktop: 64rem;
 
       --theme-banner-background-color: var(--usa-banner-background-color);
       --theme-banner-font-family: var(--usa-banner-font-family);
@@ -78,7 +79,7 @@ export const bannerStyles: CSSResultGroup = [
     section .grid-row {
       display: grid;
       grid-template-columns: repeat(
-        auto-fill,
+        auto-fit,
         minmax(min(100%, calc(var(--usa-breakpoint-tablet) / 2)), 1fr)
       );
     }
@@ -469,7 +470,7 @@ export const bannerStyles: CSSResultGroup = [
     .guidance {
       display: flex;
       align-items: flex-start;
-      max-width: 72ch;
+      max-width: 61ex;
       padding-top: var(--usa-spacing-2);
     }
 

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -16,20 +16,11 @@ export const bannerStyles: CSSResultGroup = [
       --usa-banner-link-color: var(--usa-color-blue-60v, #005ea2);
       --usa-banner-link-hover-color: #1a4480;
       --usa-banner-max-width: 1200px;
-      
-      /**
-       * The core value is set to 0.8rem, which results in a font size of 12.8px.
-       * Is subpixel rounding ok or should this be 0.75rem (12px)? 
-       */
-      --usa-banner-font-size-xs: 0.8rem; 
+      --usa-banner-font-size-xs: 0.75rem;
       --usa-banner-font-size-sm: 0.875rem;
-      --usa-banner-font-size-base: 1rem;
+      --usa-banner-font-size-base: 0.94rem;
       --usa-banner-line-height-base: 1.5;
-      /**
-       * The core value is set to 1.1, which results in a line height of 14.08.
-       * Is subpixel rounding ok to retain parity? 
-       */
-      --usa-banner-line-height-sm: 1.1;
+      --usa-banner-line-height-sm: 1.2;
 
       --usa-spacing-05: 0.25rem;
       --usa-spacing-1: 0.5rem;
@@ -126,10 +117,10 @@ export const bannerStyles: CSSResultGroup = [
       max-width: var(--usa-banner-max-width);
       margin-left: auto;
       margin-right: auto;
-      padding-left: var(--usa-spacing-2);
-      padding-right: var(--usa-spacing-2);
-      padding-bottom: var(--usa-spacing-3);
-      padding-top: var(--usa-spacing-3);
+      padding-left: var(--usa-spacing-1);
+      padding-right: var(--usa-spacing-1);
+      padding-bottom: var(--usa-spacing-2);
+      padding-top: var(--usa-spacing-05);
       background-color: var(--usa-color-transparent);
       font-size: var(--usa-banner-font-size-base);
       overflow: hidden;

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -15,6 +15,7 @@ export const bannerStyles: CSSResultGroup = [
         Helvetica, Arial, sans-serif;
       --usa-banner-link-color: var(--usa-color-blue-60v, #005ea2);
       --usa-banner-link-hover-color: #1a4480;
+      --usa-banner-focus-outline-color: #2491ff;
       --usa-banner-max-width: var(--usa-breakpoint-desktop);
       --usa-banner-font-size-xs: 0.75rem;
       --usa-banner-font-size-sm: 0.875rem;
@@ -94,7 +95,13 @@ export const bannerStyles: CSSResultGroup = [
 
     @media (min-width: 40em) {
       section .grid-row {
-        gap: var(--usa-spacing-3);
+        gap: var(--usa-spacing-2);
+      }
+    }
+    
+    @media (min-width: 64em) {
+      section .grid-row {
+        gap: calc(var(--usa-spacing-05) / 2));
       }
     }
 
@@ -259,7 +266,9 @@ export const bannerStyles: CSSResultGroup = [
     }
 
     header.expanded {
-      padding-inline-end: calc(var(--usa-size-touch-target) + var(--usa-spacing-1));
+      padding-inline-end: calc(
+        var(--usa-size-touch-target) + var(--usa-spacing-1)
+      );
     }
 
     @media (min-width: 40em) {
@@ -323,6 +332,10 @@ export const bannerStyles: CSSResultGroup = [
       }
     }
 
+    button:not([disabled]):focus {
+      outline: var(--usa-spacing-05) solid var(--usa-banner-focus-outline-color);
+    }
+
     @media (min-width: 40em) {
       button {
         position: relative;
@@ -345,7 +358,7 @@ export const bannerStyles: CSSResultGroup = [
         mask-position: center;
         position: absolute;
         top: 0;
-        right: -16px;
+        right: -18px;
         background-image: var(--usa-icon-expand-more);
         mask-image: var(--usa-icon-expand-more);
       }
@@ -460,16 +473,17 @@ export const bannerStyles: CSSResultGroup = [
       max-width: 61ex;
       padding-block-start: var(--usa-spacing-2);
     }
-    
+
     @media (max-width: 39.99em) {
       .guidance {
-        padding-inline-end: .75rem;
+        padding-inline-end: 0.75rem;
       }
     }
 
     @media (min-width: 40em) {
       .guidance {
         padding-block-start: 0;
+        padding-inline-end: var(--usa-spacing-1);
       }
     }
 

--- a/src/components/usa-banner/usa-banner.css.ts
+++ b/src/components/usa-banner/usa-banner.css.ts
@@ -49,6 +49,7 @@ export const bannerStyles: CSSResultGroup = [
       --usa-icon-close: url("/src/shared/icons/close.svg");
       --usa-icon-lock: url("/src/shared/icons/lock.svg");
     }
+
     * {
       box-sizing: border-box;
     }
@@ -69,13 +70,14 @@ export const bannerStyles: CSSResultGroup = [
     @media (min-width: 40em) {
       section {
         font-size: var(--usa-banner-font-size-xs);
-        padding-bottom: 0;
+        padding-block-end: 0;
       }
     }
 
     section .usa-accordion {
       font-family: inherit;
     }
+
     section .grid-row {
       display: grid;
       grid-template-columns: repeat(
@@ -83,24 +85,24 @@ export const bannerStyles: CSSResultGroup = [
         minmax(min(100%, calc(var(--usa-breakpoint-tablet) / 2)), 1fr)
       );
     }
-    
+
     @media (min-width: 40em) {
       section .grid-row {
         gap: var(--usa-spacing-3);
       }
     }
-    
+
     .grid-col-auto {
       flex: 0 1 auto;
     }
-    
+
     .grid-col-fill {
       flex: 1 1 0%;
       width: auto;
       max-width: 100%;
       min-width: 1px;
     }
-    
+
     @media (min-width: 40em) {
       .tablet\\:grid-col-auto {
         flex: 0 1 auto;
@@ -123,12 +125,12 @@ export const bannerStyles: CSSResultGroup = [
     .content {
       max-width: var(--usa-banner-max-width);
       line-height: var(--usa-banner-line-height-base);
-      margin-left: auto;
-      margin-right: auto;
-      padding-left: var(--usa-spacing-1);
-      padding-right: var(--usa-spacing-1);
-      padding-bottom: var(--usa-spacing-2);
-      padding-top: var(--usa-spacing-05);
+      margin-inline-start: auto;
+      margin-inline-end: auto;
+      padding-inline-start: var(--usa-spacing-1);
+      padding-inline-end: var(--usa-spacing-1);
+      padding-block-end: var(--usa-spacing-2);
+      padding-block-start: var(--usa-spacing-05);
       background-color: var(--usa-color-transparent);
       font-size: var(--usa-banner-font-size-base);
       overflow: hidden;
@@ -137,19 +139,19 @@ export const bannerStyles: CSSResultGroup = [
 
     @media (min-width: 40em) {
       .content {
-        padding-left: var(--usa-spacing-1);
-        padding-right: var(--usa-spacing-1);
-        padding-top: var(--usa-spacing-3);
-        padding-bottom: var(--usa-spacing-3);
+        padding-inline-start: var(--usa-spacing-1);
+        padding-inline-end: var(--usa-spacing-1);
+        padding-block-start: var(--usa-spacing-3);
+        padding-block-end: var(--usa-spacing-3);
       }
-    } 
-      
+    }
+
     @media (min-width: 64em) {
       .content {
-        padding-left: var(--usa-spacing-4);
-        padding-right: var(--usa-spacing-4);
-        padding-top: var(--usa-spacing-3);
-        padding-bottom: var(--usa-spacing-3);
+        padding-inline-start: var(--usa-spacing-4);
+        padding-inline-end: var(--usa-spacing-4);
+        padding-block-start: var(--usa-spacing-3);
+        padding-block-end: var(--usa-spacing-3);
       }
     }
 
@@ -158,11 +160,11 @@ export const bannerStyles: CSSResultGroup = [
     }
 
     .inner {
-      padding-left: var(--usa-spacing-2);
-      padding-right: 0;
+      padding-inline-start: var(--usa-spacing-2);
+      padding-inline-end: 0;
       max-width: var(--usa-banner-max-width);
-      margin-left: auto;
-      margin-right: auto;
+      margin-inline-start: auto;
+      margin-inline-end: auto;
       display: flex;
       flex-wrap: nowrap;
       align-items: flex-start;
@@ -173,17 +175,17 @@ export const bannerStyles: CSSResultGroup = [
         align-items: center;
       }
     }
-    
+
     @media (min-width: 64em) {
       .inner {
-        padding-left: var(--usa-spacing-4);
-        padding-right: var(--usa-spacing-4);
+        padding-inline-start: var(--usa-spacing-4);
+        padding-inline-end: var(--usa-spacing-4);
       }
     }
 
     header {
-      padding-top: var(--usa-spacing-1);
-      padding-bottom: var(--usa-spacing-1);
+      padding-block-start: var(--usa-spacing-1);
+      padding-block-end: var(--usa-spacing-1);
       font-size: var(--usa-banner-font-size-xs);
       font-weight: 400;
       min-height: var(--usa-size-touch-target);
@@ -192,30 +194,30 @@ export const bannerStyles: CSSResultGroup = [
 
     @media (min-width: 40em) {
       header {
-        padding-top: var(--usa-spacing-05);
-        padding-bottom: var(--usa-spacing-05);
+        padding-block-start: var(--usa-spacing-05);
+        padding-block-end: var(--usa-spacing-05);
         min-height: 0;
       }
     }
 
     .header-text {
-      margin-top: 0;
-      margin-bottom: 0;
+      margin-block-start: 0;
+      margin-block-end: 0;
       font-size: var(--usa-banner-font-size-xs);
       line-height: var(--usa-banner-line-height-sm);
     }
 
     .header-flag {
       float: left;
-      margin-right: var(--usa-spacing-1);
+      margin-inline-end: var(--usa-spacing-1);
       width: var(--usa-spacing-2);
-      padding-top: 0;
+      padding-block-start: 0;
     }
 
     @media (min-width: 40em) {
       .header-flag {
-        margin-right: var(--usa-spacing-1);
-        padding-top: 0;
+        margin-inline-end: var(--usa-spacing-1);
+        padding-block-start: 0;
       }
     }
 
@@ -228,8 +230,8 @@ export const bannerStyles: CSSResultGroup = [
       font: inherit;
       cursor: pointer;
       line-height: var(--usa-banner-line-height-sm);
-      margin-bottom: 0;
-      margin-top: 2px;
+      margin-block-end: 0;
+      margin-block-start: 2px;
     }
 
     .header-action:hover {
@@ -271,7 +273,7 @@ export const bannerStyles: CSSResultGroup = [
     }
 
     header.expanded {
-      padding-right: calc(var(--usa-size-touch-target) + var(--usa-spacing-1));
+      padding-inline-end: calc(var(--usa-size-touch-target) + var(--usa-spacing-1));
     }
 
     @media (min-width: 40em) {
@@ -281,17 +283,17 @@ export const bannerStyles: CSSResultGroup = [
         font-size: var(--usa-banner-font-size-sm);
         font-weight: 400;
         min-height: 0;
-        padding-right: 0;
+        padding-inline-end: 0;
       }
     }
 
     header.expanded .inner {
-      margin-left: 0;
+      margin-inline-start: 0;
     }
 
     @media (min-width: 40em) {
       header.expanded .inner {
-        margin-left: auto;
+        margin-inline-start: auto;
       }
     }
 
@@ -316,8 +318,8 @@ export const bannerStyles: CSSResultGroup = [
       font-size: var(--usa-banner-font-size-xs);
       height: auto;
       line-height: var(--usa-banner-line-height-sm);
-      padding-top: 0;
-      padding-left: 0;
+      padding-block-start: 0;
+      padding-inline-start: 0;
       text-decoration: none;
       width: auto;
     }
@@ -340,7 +342,7 @@ export const bannerStyles: CSSResultGroup = [
       button {
         position: relative;
         display: inline;
-        margin-left: var(--usa-spacing-1);
+        margin-inline-start: var(--usa-spacing-1);
         left: auto;
         top: auto;
         bottom: auto;
@@ -471,12 +473,12 @@ export const bannerStyles: CSSResultGroup = [
       display: flex;
       align-items: flex-start;
       max-width: 61ex;
-      padding-top: var(--usa-spacing-2);
+      padding-block-start: var(--usa-spacing-2);
     }
 
     @media (min-width: 40em) {
       .guidance {
-        padding-top: 0;
+        padding-block-start: 0;
       }
     }
 


### PR DESCRIPTION
# Summary

Updated typography, spacing, and layout to use CSS logical properties for better internationalization support, added fetchpriority attribute to images for performance optimization, and refined mobile and desktop styling for consistent cross-device experience.

## Related issue

Closes #157 

## Preview link

The zip file contains A/B images labeled with the device sizes for comparison. There are reference images for what is currently in core and the ones labeled "wc" are for the web components version that was updated as part of this PR.

[a-b-banner-images.zip](https://github.com/user-attachments/files/22432562/a-b-banner-images.zip)

## Problem statement

There were style inconsistencies highlighted in #137 that were in scope for this PR. The elements version of `usa-banner` should be visually indistinguishable from the version from core so its appearance is predictable for users of the component. Additionally, there was a loss of visual focus state for the expand button, the use logical props would enhanced styling capabilities for internationalization, and there could be enhanced performance for images to make sure that the icons in the banner that are only visible in the expanded state do not compete for bandwidth with other elements on a page that are in the critical rendering path.

## Solution

This PR refactors the USA Banner component to modernize its CSS architecture and improve responsive design consistency. The solution addresses layout, accessibility, performance, and internationalization concerns through comprehensive styling updates.

1. CSS Logical Properties Migration: replaced directional properties (margin-left/right, padding-left/right) with logical equivalents (margin-inline, padding-block) for better RTL language support
2. Responsive Grid and Typography Updates: added styling at various breakpoints to achieve visual parity with core
3. Performance Optimizations: added `fetchpriority="low"` attributes to images that are only visible after the user expands the banner.
4. Accessibility Enhancements: added proper focus outline styles and improved button formatting to prevent unwanted whitespace

## Testing and review

You can pull this code down and run it in storybook or use the images in the attached zip file to compare the web component (i.e. element) version with the current version of the banner (suffixed with "core" in the zip file) as it appears in `@uswds/uswds@3.13.0`