### PR TITLE
Web components : Add pre-commit checks via Husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+npm run prettier:js:fix
+npm run prettier:md:fix
+npm run stylelint:fix
+npm run test:ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-storybook": "9.0.18",
         "http-server": "^14.1.1",
+        "husky": "^9.1.7",
         "jsdom": "^24.1.1",
         "postcss-lit": "^1.2.0",
         "prettier": "^3.6.2",
@@ -7494,6 +7495,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyperdyperid": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "test:ci": "vitest run",
     "test:storybook:ci": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"npm run storybook:build --quiet && npx http-server storybook-static --port 6006 --silent\" \"wait-on tcp:127.0.0.1:6006 && npx test-storybook\"",
     "vite:preview": "vite preview",
-    "pages": "npm run storybook:build && cp -r storybook-static _site"
+    "pages": "npm run storybook:build && cp -r storybook-static _site",
+    "prepare": "husky"
   },
   "dependencies": {
     "@uswds/uswds": "^3.11.0",
@@ -64,6 +65,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-storybook": "9.0.18",
     "http-server": "^14.1.1",
+    "husky": "^9.1.7",
     "jsdom": "^24.1.1",
     "postcss-lit": "^1.2.0",
     "prettier": "^3.6.2",


### PR DESCRIPTION
# Summary

Added pre-commit hooks using Husky to automate code formatting and testing before commits.

Closes #171

This PR adds automated code quality checks prior to committing changes, which can lead to inconsistencies in code style and potentially introduce untested code into the codebase.

The desired state is a codebase where all committed code adheres to predefined formatting standards and passes automated tests, ensuring higher code quality and consistency. Currently, these checks run in CI, but we can quicken the feedback loop and conserve the CI minutes by catching things in a precommit hook.

*   Added `husky` package as a dev dependency.
*   Configured a `.husky/pre-commit` hook to automatically run stylelint and prettier code formatting fixes, as well as the unit test script
*   Added a `prepare` script to `package.json` to enable Husky on `npm install`.

_To review this change, please follow these steps:_
1.  Clone the repository and run `npm install` to ensure Husky hooks are set up correctly.
2.  Introduce a formatting error (e.g., an unformatted JavaScript file or Markdown file) and attempt to commit it. Verify that the pre-commit hook automatically fixes the formatting or prevents the commit if it cannot be fixed automatically.
3.  Introduce a failing test and attempt to commit it. Verify that the pre-commit hook prevents the commit due to the failing test.
4.  Make a valid, well-formatted change with passing tests and commit it successfully.

I am looking for feedback on the effectiveness of the hooks and any potential impacts on the commit process.

| Dependency name | Previous version | New version |
| :-------------- | :--------------: | :---------: |
| husky           |        --        |   9.1.7     |