### PR TITLE
Web components: Implement and refine web vitals performance testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,8 @@ COPY . .
 # Expose default Storybook port
 EXPOSE 3000
 
+# Expose port for reports if there are test failures
+EXPOSE 9323
+
 # Default entrypoint; override in docker-compose or docker run
 CMD [ "bash" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,6 @@ services:
       - /workspace/node_modules # Keeps node_modules inside container
     ports:
       - "3000:3000" # Storybook Express server
+      - "9323:9323" # Playwright report port in the event o f test failure
     stdin_open: true
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       - /workspace/node_modules # Keeps node_modules inside container
     ports:
       - "3000:3000" # Storybook Express server
-      - "9323:9323" # Playwright report port in the event o f test failure
+      - "9323:9323" # Playwright report port in the event of test failure
     stdin_open: true
     tty: true

--- a/e2e/components/usa-banner/usa-banner.performance.spec.ts
+++ b/e2e/components/usa-banner/usa-banner.performance.spec.ts
@@ -4,7 +4,6 @@ import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
 
-// Get __dirname equivalent for ES modules
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -19,16 +18,8 @@ test.describe("usa-banner performance", () => {
   // Web vitals are collected differently for each browser.
   // Some metrics may be collected inconsistently or not at all.
   test("should have good web vitals", async ({ page }) => {
-    // Set up page listeners
-    page.on("console", async (msg) => {
-      if (msg.type() === "trace" || msg.type() === "error") {
-        console.log(msg.text());
-      }
-    });
-
     const badMetrics: string[] = [];
     function validateMetric(name: string, good: boolean) {
-      console.log(`${name} valid: ${good}`);
       if (!good) {
         badMetrics.push(name);
       }
@@ -66,7 +57,6 @@ test.describe("usa-banner performance", () => {
           // > switched tabs, or the page starts to unload.
           // See: https://github.com/GoogleChrome/web-vitals#:~:text=Note%20that%20some%20of%20these%20metrics%20will%20not%20report%20until%20the%20user%20has%20interacted%20with%20the%20page%2C%20switched%20tabs%2C%20or%20the%20page%20starts%20to%20unload.
           function checkMetric(m: webVitals.Metric) {
-            console.trace(JSON.stringify(m, null, 4));
             if (m.rating !== "good") {
               window.validateMetric(m.name, false);
               return;
@@ -79,13 +69,11 @@ test.describe("usa-banner performance", () => {
           window.webVitals.onINP(checkMetric);
           window.webVitals.onLCP(checkMetric);
           window.webVitals.onTTFB(checkMetric);
-          console.log("Initialized web vital monitors");
         });
       },
       [scriptBody],
     );
 
-    // Go to Hacker News, record FCP and TTFB
     const storyName = "components-banner--default";
     const storyUrl = `http://localhost:3000/iframe.html?globals=&args=&id=${storyName}&viewMode=story`;
 
@@ -93,7 +81,6 @@ test.describe("usa-banner performance", () => {
 
     // Page click to record LCP and FID
     await page.waitForLoadState("domcontentloaded");
-    console.log("Page click");
     await page.getByRole("button", { name: "Here’s how you know" }).click();
 
     // Manually obtain navigation event metrics for page load time
@@ -102,12 +89,9 @@ test.describe("usa-banner performance", () => {
     const [navTiming] = await page.evaluate(() =>
       window.performance.getEntriesByType("navigation").map((e) => e.toJSON()),
     );
-    console.debug("Navigation Entry:", navTiming);
-    console.log("Page load time:", navTiming.loadEventEnd);
     validateMetric("Page load", navTiming.loadEventEnd < 2000);
 
     // Page unload to record INP and CLS
-    console.log("Page unload");
     await page.close();
     expect(badMetrics).toHaveLength(0);
   });

--- a/e2e/components/usa-banner/usa-banner.performance.spec.ts
+++ b/e2e/components/usa-banner/usa-banner.performance.spec.ts
@@ -1,76 +1,8 @@
-import { test, expect } from "@playwright/test";
-import type * as webVitals from "web-vitals";
-import path from "path";
-import fs from "fs";
-import { fileURLToPath } from "url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-declare global {
-  interface Window {
-    webVitals: typeof webVitals;
-    validateMetric: (name: string, good: boolean) => void;
-  }
-}
+import { test, expect } from "../../fixtures/web-vitals";
 
 test.describe("usa-banner performance", () => {
-  test("should have good web vitals", async ({ page }) => {
-    const badMetrics: string[] = [];
-    function validateMetric(name: string, good: boolean) {
-      if (!good) {
-        badMetrics.push(name);
-      }
-    }
-    await page.exposeFunction("validateMetric", validateMetric);
-
-    // Using classic script to get webVitals global namespace
-    const scriptPath = path.join(
-      __dirname,
-      "../../../",
-      "node_modules/web-vitals/dist/web-vitals.attribution.iife.js",
-    );
-    // Read the web-vitals script content at runtime
-    const scriptBody = fs.readFileSync(scriptPath, "utf8");
-
-    /*
-     * Inject the script into the page.
-     * Make sure to use the raw script content instead of creating a script with the src set to `webVitalsUrl`.
-     * Otherwise, the external script may get blocked on certain websites.
-     */
-    await page.addInitScript(
-      async ([scriptBody]) => {
-        window.addEventListener("DOMContentLoaded", async () => {
-          const script = document.createElement("script");
-          script.text = scriptBody;
-          try {
-            document.head.appendChild(script);
-          } catch (e) {
-            console.error("Error when initializing injected CWV script");
-            console.error(e);
-          }
-
-          // From GoogleChrome/web-vitals:
-          // > Note that some of these metrics will not report until the user has interacted with the page,
-          // > switched tabs, or the page starts to unload.
-          // See: https://github.com/GoogleChrome/web-vitals#:~:text=Note%20that%20some%20of%20these%20metrics%20will%20not%20report%20until%20the%20user%20has%20interacted%20with%20the%20page%2C%20switched%20tabs%2C%20or%20the%20page%20starts%20to%20unload.
-          function checkMetric(m: webVitals.Metric) {
-            if (m.rating !== "good") {
-              window.validateMetric(m.name, false);
-              return;
-            }
-            window.validateMetric(m.name, true);
-          }
-
-          window.webVitals.onCLS(checkMetric);
-          window.webVitals.onFCP(checkMetric);
-          window.webVitals.onINP(checkMetric);
-          window.webVitals.onLCP(checkMetric);
-          window.webVitals.onTTFB(checkMetric);
-        });
-      },
-      [scriptBody],
-    );
+  test("should have good web vitals", async ({ page, webVitals }) => {
+    await webVitals.setup();
 
     const storyName = "components-banner--default";
     const storyUrl = `http://localhost:3000/iframe.html?globals=&args=&id=${storyName}&viewMode=story`;
@@ -83,6 +15,6 @@ test.describe("usa-banner performance", () => {
 
     // Page unload to record INP and CLS
     await page.close();
-    expect(badMetrics).toHaveLength(0);
+    expect(webVitals.badMetrics).toHaveLength(0);
   });
 });

--- a/e2e/components/usa-banner/usa-banner.performance.spec.ts
+++ b/e2e/components/usa-banner/usa-banner.performance.spec.ts
@@ -1,16 +1,14 @@
 import { test, expect } from "../../fixtures/web-vitals";
+import { StorybookPage } from "../../models/storybook-page";
 
 test.describe("usa-banner performance", () => {
   test("should have good web vitals", async ({ page, webVitals }) => {
     await webVitals.setup();
 
-    const storyName = "components-banner--default";
-    const storyUrl = `http://localhost:3000/iframe.html?globals=&args=&id=${storyName}&viewMode=story`;
-
-    await page.goto(storyUrl);
+    const storybookPage = new StorybookPage(page);
+    await storybookPage.gotoAndWaitForDomLoaded("components-banner--default");
 
     // Page click to record LCP and FID
-    await page.waitForLoadState("domcontentloaded");
     await page.getByRole("button", { name: "Here’s how you know" }).click();
 
     // Page unload to record INP and CLS

--- a/e2e/components/usa-banner/usa-banner.performance.spec.ts
+++ b/e2e/components/usa-banner/usa-banner.performance.spec.ts
@@ -15,6 +15,6 @@ test.describe("usa-banner performance", () => {
 
     // Page unload to record INP and CLS
     await page.close();
-    expect(webVitals.badMetrics).toHaveLength(0);
+    expect(webVitals.failingMetrics).toHaveLength(0);
   });
 });

--- a/e2e/components/usa-banner/usa-banner.performance.spec.ts
+++ b/e2e/components/usa-banner/usa-banner.performance.spec.ts
@@ -15,8 +15,6 @@ declare global {
 }
 
 test.describe("usa-banner performance", () => {
-  // Web vitals are collected differently for each browser.
-  // Some metrics may be collected inconsistently or not at all.
   test("should have good web vitals", async ({ page }) => {
     const badMetrics: string[] = [];
     function validateMetric(name: string, good: boolean) {
@@ -82,14 +80,6 @@ test.describe("usa-banner performance", () => {
     // Page click to record LCP and FID
     await page.waitForLoadState("domcontentloaded");
     await page.getByRole("button", { name: "Here’s how you know" }).click();
-
-    // Manually obtain navigation event metrics for page load time
-    // - NOTE: There is only one PerformanceNavigationTiming object in the performance timeline
-    //   See: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
-    const [navTiming] = await page.evaluate(() =>
-      window.performance.getEntriesByType("navigation").map((e) => e.toJSON()),
-    );
-    validateMetric("Page load", navTiming.loadEventEnd < 2000);
 
     // Page unload to record INP and CLS
     await page.close();

--- a/e2e/components/usa-banner/usa-banner.performance.spec.ts
+++ b/e2e/components/usa-banner/usa-banner.performance.spec.ts
@@ -8,7 +8,7 @@ test.describe("usa-banner performance", () => {
     const storybookPage = new StorybookPage(page);
     await storybookPage.gotoAndWaitForDomLoaded("components-banner--default");
 
-    // Page click to record LCP and FID
+    // Page click to record LCP
     await page.getByRole("button", { name: "Here’s how you know" }).click();
 
     // Page unload to record INP and CLS

--- a/e2e/components/usa-banner/usa-banner.performance.spec.ts
+++ b/e2e/components/usa-banner/usa-banner.performance.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from "@playwright/test";
+import type * as webVitals from "web-vitals";
+import path from "path";
+import fs from "fs";
+import { fileURLToPath } from "url";
+
+// Get __dirname equivalent for ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+declare global {
+  interface Window {
+    webVitals: typeof webVitals;
+    validateMetric: (name: string, good: boolean) => void;
+  }
+}
+
+test.describe("usa-banner performance", () => {
+  // Web vitals are collected differently for each browser.
+  // Some metrics may be collected inconsistently or not at all.
+  test("should have good web vitals", async ({ page }) => {
+    // Set up page listeners
+    page.on("console", async (msg) => {
+      if (msg.type() === "trace" || msg.type() === "error") {
+        console.log(msg.text());
+      }
+    });
+
+    const badMetrics: string[] = [];
+    function validateMetric(name: string, good: boolean) {
+      console.log(`${name} valid: ${good}`);
+      if (!good) {
+        badMetrics.push(name);
+      }
+    }
+    await page.exposeFunction("validateMetric", validateMetric);
+
+    // Using classic script to get webVitals global namespace
+    const scriptPath = path.join(
+      __dirname,
+      "../../../",
+      "node_modules/web-vitals/dist/web-vitals.attribution.iife.js",
+    );
+    // Read the web-vitals script content at runtime
+    const scriptBody = fs.readFileSync(scriptPath, "utf8");
+
+    /*
+     * Inject the script into the page.
+     * Make sure to use the raw script content instead of creating a script with the src set to `webVitalsUrl`.
+     * Otherwise, the external script may get blocked on certain websites.
+     */
+    await page.addInitScript(
+      async ([scriptBody]) => {
+        window.addEventListener("DOMContentLoaded", async () => {
+          const script = document.createElement("script");
+          script.text = scriptBody;
+          try {
+            document.head.appendChild(script);
+          } catch (e) {
+            console.error("Error when initializing injected CWV script");
+            console.error(e);
+          }
+
+          // From GoogleChrome/web-vitals:
+          // > Note that some of these metrics will not report until the user has interacted with the page,
+          // > switched tabs, or the page starts to unload.
+          // See: https://github.com/GoogleChrome/web-vitals#:~:text=Note%20that%20some%20of%20these%20metrics%20will%20not%20report%20until%20the%20user%20has%20interacted%20with%20the%20page%2C%20switched%20tabs%2C%20or%20the%20page%20starts%20to%20unload.
+          function checkMetric(m: webVitals.Metric) {
+            console.trace(JSON.stringify(m, null, 4));
+            if (m.rating !== "good") {
+              window.validateMetric(m.name, false);
+              return;
+            }
+            window.validateMetric(m.name, true);
+          }
+
+          window.webVitals.onCLS(checkMetric);
+          window.webVitals.onFCP(checkMetric);
+          window.webVitals.onINP(checkMetric);
+          window.webVitals.onLCP(checkMetric);
+          window.webVitals.onTTFB(checkMetric);
+          console.log("Initialized web vital monitors");
+        });
+      },
+      [scriptBody],
+    );
+
+    // Go to Hacker News, record FCP and TTFB
+    const storyName = "components-banner--default";
+    const storyUrl = `http://localhost:3000/iframe.html?globals=&args=&id=${storyName}&viewMode=story`;
+
+    await page.goto(storyUrl);
+
+    // Page click to record LCP and FID
+    await page.waitForLoadState("domcontentloaded");
+    console.log("Page click");
+    await page.getByRole("button", { name: "Here’s how you know" }).click();
+
+    // Manually obtain navigation event metrics for page load time
+    // - NOTE: There is only one PerformanceNavigationTiming object in the performance timeline
+    //   See: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
+    const [navTiming] = await page.evaluate(() =>
+      window.performance.getEntriesByType("navigation").map((e) => e.toJSON()),
+    );
+    console.debug("Navigation Entry:", navTiming);
+    console.log("Page load time:", navTiming.loadEventEnd);
+    validateMetric("Page load", navTiming.loadEventEnd < 2000);
+
+    // Page unload to record INP and CLS
+    console.log("Page unload");
+    await page.close();
+    expect(badMetrics).toHaveLength(0);
+  });
+});

--- a/e2e/components/usa-banner/usa-banner.spec.ts
+++ b/e2e/components/usa-banner/usa-banner.spec.ts
@@ -1,11 +1,12 @@
 import { test, expect } from "@playwright/test";
+import { StorybookPage } from "../../models/storybook-page";
 
 test.describe("usa-banner visual regression tests", () => {
   const storyName = "components-banner--default";
-  const storyUrl = `http://localhost:3000/iframe.html?globals=&args=&id=${storyName}&viewMode=story`;
 
   test.beforeEach(async ({ page }) => {
-    await page.goto(storyUrl);
+    const storybookPage = new StorybookPage(page);
+    await storybookPage.gotoAndWaitForDomLoaded(storyName);
   });
 
   test("Collapsed state should match visual snapshot", async ({ page }) => {

--- a/e2e/fixtures/web-vitals.ts
+++ b/e2e/fixtures/web-vitals.ts
@@ -68,4 +68,5 @@ export const test = base.extend<WebVitalsFixture>({
   },
 });
 
+// @ts-expect-error expect is passing through for convenience in the test file
 export { expect } from "@playwright/test";

--- a/e2e/fixtures/web-vitals.ts
+++ b/e2e/fixtures/web-vitals.ts
@@ -1,11 +1,5 @@
 import { test as base } from "@playwright/test";
 import type * as webVitals from "web-vitals";
-import path from "path";
-import fs from "fs";
-import { fileURLToPath } from "url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 declare global {
   interface Window {
@@ -36,31 +30,14 @@ export const test = base.extend<WebVitalsFixture>({
     const setup = async () => {
       await page.exposeFunction("validateMetric", validateMetric);
 
-      // Using classic script to get webVitals global namespace
-      const scriptPath = path.join(
-        __dirname,
-        "../../",
-        "node_modules/web-vitals/dist/web-vitals.attribution.iife.js",
-      );
-      // Read the web-vitals script content at runtime
-      const scriptBody = fs.readFileSync(scriptPath, "utf8");
-
       /*
-       * Inject the script into the page.
-       * Make sure to use the raw script content instead of creating a script with the src set to `webVitalsUrl`.
-       * Otherwise, the external script may get blocked on certain websites.
+       * Inject the script into the page using ES6 module imports.
+       * This approach dynamically imports the web-vitals library at runtime.
        */
-      await page.addInitScript(
-        async ([scriptBody]) => {
-          window.addEventListener("DOMContentLoaded", async () => {
-            const script = document.createElement("script");
-            script.text = scriptBody;
-            try {
-              document.head.appendChild(script);
-            } catch (e) {
-              console.error("Error when initializing injected CWV script");
-              console.error(e);
-            }
+      await page.addInitScript(async () => {
+        window.addEventListener("DOMContentLoaded", async () => {
+          try {
+            window.webVitals = await import("web-vitals/attribution");
 
             // From GoogleChrome/web-vitals:
             // > Note that some of these metrics will not report until the user has interacted with the page,
@@ -79,10 +56,12 @@ export const test = base.extend<WebVitalsFixture>({
             window.webVitals.onINP(checkMetric);
             window.webVitals.onLCP(checkMetric);
             window.webVitals.onTTFB(checkMetric);
-          });
-        },
-        [scriptBody],
-      );
+          } catch (e) {
+            console.error("Error when initializing injected CWV script");
+            console.error(e);
+          }
+        });
+      });
     };
 
     await use({ badMetrics, setup });

--- a/e2e/fixtures/web-vitals.ts
+++ b/e2e/fixtures/web-vitals.ts
@@ -10,7 +10,7 @@ declare global {
 
 type WebVitalsFixture = {
   webVitals: {
-    badMetrics: string[];
+    failingMetrics: string[];
     setup: () => Promise<void>;
   };
 };
@@ -19,11 +19,11 @@ type WebVitalsFixture = {
 // https://gist.github.com/cloudydaiyz/923ca44bdb0a1ff3434a9360967025a6
 export const test = base.extend<WebVitalsFixture>({
   webVitals: async ({ page }, use) => {
-    const badMetrics: string[] = [];
+    const failingMetrics: string[] = [];
 
-    function validateMetric(name: string, good: boolean) {
-      if (!good) {
-        badMetrics.push(name);
+    function validateMetric(name: string, isWithinThreshold: boolean) {
+      if (!isWithinThreshold) {
+        failingMetrics.push(name);
       }
     }
 
@@ -43,12 +43,12 @@ export const test = base.extend<WebVitalsFixture>({
             // > Note that some of these metrics will not report until the user has interacted with the page,
             // > switched tabs, or the page starts to unload.
             // See: https://github.com/GoogleChrome/web-vitals#:~:text=Note%20that%20some%20of%20these%20metrics%20will%20not%20report%20until%20the%20user%20has%20interacted%20with%20the%20page%2C%20switched%20tabs%2C%20or%20the%20page%20starts%20to%20unload.
-            function checkMetric(m: webVitals.Metric) {
-              if (m.rating !== "good") {
-                window.validateMetric(m.name, false);
+            function checkMetric(metric: webVitals.Metric) {
+              if (metric.rating !== "good") {
+                window.validateMetric(metric.name, false);
                 return;
               }
-              window.validateMetric(m.name, true);
+              window.validateMetric(metric.name, true);
             }
 
             window.webVitals.onCLS(checkMetric);
@@ -64,7 +64,7 @@ export const test = base.extend<WebVitalsFixture>({
       });
     };
 
-    await use({ badMetrics, setup });
+    await use({ failingMetrics, setup });
   },
 });
 

--- a/e2e/fixtures/web-vitals.ts
+++ b/e2e/fixtures/web-vitals.ts
@@ -1,0 +1,92 @@
+import { test as base } from "@playwright/test";
+import type * as webVitals from "web-vitals";
+import path from "path";
+import fs from "fs";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+declare global {
+  interface Window {
+    webVitals: typeof webVitals;
+    validateMetric: (name: string, good: boolean) => void;
+  }
+}
+
+type WebVitalsFixture = {
+  webVitals: {
+    badMetrics: string[];
+    setup: () => Promise<void>;
+  };
+};
+
+// This approach was heavily inspired by
+// https://gist.github.com/cloudydaiyz/923ca44bdb0a1ff3434a9360967025a6
+export const test = base.extend<WebVitalsFixture>({
+  webVitals: async ({ page }, use) => {
+    const badMetrics: string[] = [];
+
+    function validateMetric(name: string, good: boolean) {
+      if (!good) {
+        badMetrics.push(name);
+      }
+    }
+
+    const setup = async () => {
+      await page.exposeFunction("validateMetric", validateMetric);
+
+      // Using classic script to get webVitals global namespace
+      const scriptPath = path.join(
+        __dirname,
+        "../../",
+        "node_modules/web-vitals/dist/web-vitals.attribution.iife.js",
+      );
+      // Read the web-vitals script content at runtime
+      const scriptBody = fs.readFileSync(scriptPath, "utf8");
+
+      /*
+       * Inject the script into the page.
+       * Make sure to use the raw script content instead of creating a script with the src set to `webVitalsUrl`.
+       * Otherwise, the external script may get blocked on certain websites.
+       */
+      await page.addInitScript(
+        async ([scriptBody]) => {
+          window.addEventListener("DOMContentLoaded", async () => {
+            const script = document.createElement("script");
+            script.text = scriptBody;
+            try {
+              document.head.appendChild(script);
+            } catch (e) {
+              console.error("Error when initializing injected CWV script");
+              console.error(e);
+            }
+
+            // From GoogleChrome/web-vitals:
+            // > Note that some of these metrics will not report until the user has interacted with the page,
+            // > switched tabs, or the page starts to unload.
+            // See: https://github.com/GoogleChrome/web-vitals#:~:text=Note%20that%20some%20of%20these%20metrics%20will%20not%20report%20until%20the%20user%20has%20interacted%20with%20the%20page%2C%20switched%20tabs%2C%20or%20the%20page%20starts%20to%20unload.
+            function checkMetric(m: webVitals.Metric) {
+              if (m.rating !== "good") {
+                window.validateMetric(m.name, false);
+                return;
+              }
+              window.validateMetric(m.name, true);
+            }
+
+            window.webVitals.onCLS(checkMetric);
+            window.webVitals.onFCP(checkMetric);
+            window.webVitals.onINP(checkMetric);
+            window.webVitals.onLCP(checkMetric);
+            window.webVitals.onTTFB(checkMetric);
+          });
+        },
+        [scriptBody],
+      );
+    };
+
+    await use({ badMetrics, setup });
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/fixtures/web-vitals.ts
+++ b/e2e/fixtures/web-vitals.ts
@@ -68,5 +68,4 @@ export const test = base.extend<WebVitalsFixture>({
   },
 });
 
-// @ts-expect-error expect is passing through for convenience in the test file
 export { expect } from "@playwright/test";

--- a/e2e/models/storybook-page.ts
+++ b/e2e/models/storybook-page.ts
@@ -1,0 +1,50 @@
+import { Page } from "@playwright/test";
+
+export class StorybookPage {
+  constructor(private readonly page: Page) {}
+
+  /**
+   * Navigate to a specific story
+   * @param storyId - The story ID (e.g., "components-banner--default")
+   * @param options - Additional options for the story URL
+   */
+  async goto(
+    storyId: string,
+    options?: {
+      globals?: string;
+      args?: string;
+      viewMode?: "story" | "docs";
+      baseUrl?: string;
+    },
+  ) {
+    const {
+      globals = "",
+      args = "",
+      viewMode = "story",
+      baseUrl = "http://localhost:3000",
+    } = options || {};
+
+    const storyUrl = `${baseUrl}/iframe.html?globals=${globals}&args=${args}&id=${storyId}&viewMode=${viewMode}`;
+    await this.page.goto(storyUrl);
+  }
+
+  /**
+   * Navigate to a specific story and wait for the DOM to be fully loaded
+   * @param storyId - The story ID (e.g., "components-banner--default")
+   * @param options - Additional options for the story URL
+   */
+  async gotoAndWaitForDomLoaded(
+    storyId: string,
+    options?: Parameters<StorybookPage["goto"]>[1],
+  ) {
+    await this.goto(storyId, options);
+    await this.page.waitForLoadState("domcontentloaded");
+  }
+
+  /**
+   * Get the current page instance
+   */
+  getPage(): Page {
+    return this.page;
+  }
+}

--- a/e2e/models/storybook-page.ts
+++ b/e2e/models/storybook-page.ts
@@ -29,7 +29,7 @@ export class StorybookPage {
   }
 
   /**
-   * Navigate to a specific story and wait for the DOM to be fully loaded
+   * Navigate to a specific story and wait for the DOM to be loaded
    * @param storyId - The story ID (e.g., "components-banner--default")
    * @param options - Additional options for the story URL
    */
@@ -39,12 +39,5 @@ export class StorybookPage {
   ) {
     await this.goto(storyId, options);
     await this.page.waitForLoadState("domcontentloaded");
-  }
-
-  /**
-   * Get the current page instance
-   */
-  getPage(): Page {
-    return this.page;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
         "vite-plugin-bundlesize": "^0.3.0",
         "vite-plugin-lit-css": "^2.2.1",
         "vitest": "^3.2.4",
-        "wait-on": "^7.2.0"
+        "wait-on": "^7.2.0",
+        "web-vitals": "^5.1.0"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.34.6"
@@ -14351,6 +14352,13 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "vite-plugin-bundlesize": "^0.3.0",
     "vite-plugin-lit-css": "^2.2.1",
     "vitest": "^3.2.4",
-    "wait-on": "^7.2.0"
+    "wait-on": "^7.2.0",
+    "web-vitals": "^5.1.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.34.6"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,11 +42,13 @@ export default defineConfig({
     {
       name: "firefox",
       use: { ...devices["Desktop Firefox"] },
+      testIgnore: ["**/*performance.spec.ts"],
     },
 
     {
       name: "webkit",
       use: { ...devices["Desktop Safari"] },
+      testIgnore: ["**/*performance.spec.ts"],
     },
 
     {
@@ -56,16 +58,19 @@ export default defineConfig({
     {
       name: "Mobile Safari",
       use: { ...devices["iPhone 12"] },
+      testIgnore: ["**/*performance.spec.ts"],
     },
 
     // Add tablet configurations
     {
       name: "Tablet Chrome",
       use: { ...devices["iPad Pro"] },
+      testIgnore: ["**/*performance.spec.ts"],
     },
     {
       name: "Tablet Safari",
       use: { ...devices["iPad Pro"] },
+      testIgnore: ["**/*performance.spec.ts"],
     },
   ],
 


### PR DESCRIPTION
## Summary

Introduced a comprehensive web vitals performance testing framework, initially applied to the `usa-banner` component, to ensure optimal user experience and identify performance regressions early.

Closes #183 

Preview link: N/A; changes are related to test code only.

## Problem

Web components should meet core web vitals performance standards to provide a fast and responsive user experience. Performance regressions, such as slow rendering or janky interactions, were not automatically detected, leading to potential degradation in user experience without clear visibility into the root causes.

## Solution

This PR establishes automated performance testing using Playwright and the `web-vitals` library. The solution provides a structured way to measure [Core Web Vitals](https://web.dev/articles/vitals) for web components within an end-to-end testing environment.

*   **What the solution is:** A Playwright-based testing setup that integrates the `web-vitals` library to capture and assert against performance metrics for rendered web components.
*   **Why this approach was chosen:** Playwright offers powerful browser automation capabilities, making it ideal for simulating user interactions and measuring in-browser performance. The official `web-vitals` library is the standard for collecting these metrics. Encapsulating the setup in a Playwright fixture (`e2e/fixtures/web-vitals.ts`) promotes reusability across future component performance tests, while the `StorybookPage` Page Object Model simplifies test authoring.
*   **How it was implemented:**
    *   The `web-vitals` npm package was added as a development dependency.
    *   A Playwright fixture (`web-vitals.ts`) was created to manage the injection of the `web-vitals` script into the test page and to expose a callback (`validateMetric`) for tests to record failing metrics. This fixture was updated to use dynamic ES module imports for the `web-vitals` library, replacing a less efficient `fs.readFileSync` approach.
    *   An initial performance test (`usa-banner.performance.spec.ts`) was developed for the `usa-banner` component, utilizing the new `web-vitals` fixture to assert that no Core Web Vitals fall outside "good" thresholds.
    *   `playwright.config.ts` was updated to limit performance tests to the Chromium browser profile, as browser support for all core web vitals metrics is inconsistent across other browsers at the time of this PR.
    *   A `StorybookPage` Page Object Model was introduced to standardize and simplify navigation to Storybook stories within Playwright tests, making tests more readable and maintainable.
*   **Possible limitations:** Performance metrics can be sensitive to the environment where tests are run (e.g., CI runner resource allocation).

## Significant updates:

*   **Added `web-vitals` Playwright fixture:** A reusable fixture (`e2e/fixtures/web-vitals.ts`) for setting up web vitals monitoring in Playwright tests.
*   **Initial performance test for `usa-banner`:** The `e2e/components/usa-banner/usa-banner.performance.spec.ts` file introduces the first component-specific performance test.
*   **New `StorybookPage` Page Object Model:** Created `e2e/models/storybook-page.ts` to abstract Storybook navigation logic, improving test readability and maintainability.
*   **Dynamic `web-vitals` import:** The `web-vitals` fixture dynamically imports the library into the test code and does not add any extra code to the components themselves.

## Reviewing this change

-  Run Playwright end-to-end tests and ensure they are passing.

I am seeking feedback on the overall design of the performance testing framework, the clarity and reusability of the `web-vitals` fixture, the utility of the `StorybookPage` POM, and any suggestions for improving metric reliability or expanding test coverage.

| Dependency name | Previous version | New version |
| :---------------- | :--------------: | :---------: |
| `web-vitals`    |        --        |   `5.1.0`   |