### PR TITLE
Web components: Document example of custom banner theming

### DIFF
--- a/src/components/usa-banner/banner.stories.js
+++ b/src/components/usa-banner/banner.stories.js
@@ -91,11 +91,16 @@ export const EspañolMil = {
 };
 
 export const CustomThemeExample = {
+  parameters: {
+    docs: {
+      disable: true,
+    },
+  },
   args: {
     "--usa-banner-background-color": "#0f191c", // blue-cool-90
     "--usa-banner-button-close-background-color": "#002d3f", // blue-cool-80-vivid
     "--usa-banner-focus-outline-color": "#52daf2", // cyan-20-vivid
-    "--usa-banner-font-family": "sans-serif",
+    "--usa-banner-font-family": "monospace",
     "--usa-banner-link-hover-color": "#c3ebfa", // blue-cool-10-vivid
     "--usa-banner-text-color": "#ffffff",
     "--usa-banner-link-color": "#97d4ea", // blue-cool-20-vivid

--- a/src/components/usa-banner/banner.stories.js
+++ b/src/components/usa-banner/banner.stories.js
@@ -100,7 +100,8 @@ export const CustomThemeExample = {
     "--usa-banner-background-color": "#0f191c", // blue-cool-90
     "--usa-banner-button-close-background-color": "#002d3f", // blue-cool-80-vivid
     "--usa-banner-focus-outline-color": "#52daf2", // cyan-20-vivid
-    "--usa-banner-font-family": "monospace",
+    "--usa-banner-font-family":
+      "ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace",
     "--usa-banner-link-hover-color": "#c3ebfa", // blue-cool-10-vivid
     "--usa-banner-text-color": "#ffffff",
     "--usa-banner-link-color": "#97d4ea", // blue-cool-20-vivid

--- a/src/components/usa-banner/banner.stories.js
+++ b/src/components/usa-banner/banner.stories.js
@@ -90,7 +90,24 @@ export const EspañolMil = {
   },
 };
 
-export const ToggleBanner = {
+export const CustomThemeExample = {
+  args: {
+    "--usa-banner-background-color": "#0f191c", // blue-cool-90
+    "--usa-banner-button-close-background-color": "#002d3f", // blue-cool-80-vivid
+    "--usa-banner-focus-outline-color": "#52daf2", // cyan-20-vivid
+    "--usa-banner-font-family": "sans-serif",
+    "--usa-banner-link-hover-color": "#c3ebfa", // blue-cool-10-vivid
+    "--usa-banner-text-color": "#ffffff",
+    "--usa-banner-link-color": "#97d4ea", // blue-cool-20-vivid
+  },
+};
+
+export const ToggleBannerTest = {
+  parameters: {
+    docs: {
+      disable: true,
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByShadowRole("button");

--- a/src/components/usa-banner/docs.mdx
+++ b/src/components/usa-banner/docs.mdx
@@ -14,7 +14,7 @@ Banners identify official websites of government organizations in the United Sta
 
 ## About the banner component
 
-<p class="site-note">
+<p className="site-note">
   <strong>Note:</strong> Banners and identifiers are core components. We
   recommend using both core components on most sites. Together, they are the
   most recognizable and standardized design elements of a government site.
@@ -97,7 +97,7 @@ Some `.mil` websites don’t belong to an official U.S. Department of War organi
 
 The banner should directly follow the `skipnav` component.
 
-<p class="site-note">
+<p className="site-note">
   <strong>Note:</strong> As this is the first Web Component shipping in USWDS,
   we are still working on the best way to document its usage. We want to hear
   from users about challenges with adding this component to your projects.

--- a/src/components/usa-banner/docs.mdx
+++ b/src/components/usa-banner/docs.mdx
@@ -14,11 +14,9 @@ Banners identify official websites of government organizations in the United Sta
 
 ## About the banner component
 
-<p className="site-note">
-  <strong>Note:</strong> Banners and identifiers are core components. We
-  recommend using both core components on most sites. Together, they are the
-  most recognizable and standardized design elements of a government site.
-</p>
+<strong>Note:</strong> Banners and identifiers are core components. We recommend
+using both core components on most sites. Together, they are the most
+recognizable and standardized design elements of a government site.
 
 You should use the banner to identify your site as an official government site.
 
@@ -97,14 +95,9 @@ Some `.mil` websites don’t belong to an official U.S. Department of War organi
 
 The banner should directly follow the `skipnav` component.
 
-<p className="site-note">
-  <strong>Note:</strong> As this is the first Web Component shipping in USWDS,
-  we are still working on the best way to document its usage. We want to hear
-  from users about challenges with adding this component to your projects.
-  Please let us know what works, what doesn’t, and what additional documentation
-  might be helpful in this{" "}
-  <a href="https://github.com/uswds/uswds/discussions/6477">
-    discussion thread
-  </a>
-  .
-</p>
+<strong>Note:</strong> As this is the first Web Component shipping in USWDS, we
+are still working on the best way to document its usage. We want to hear from
+users about challenges with adding this component to your projects. Please let
+us know what works, what doesn’t, and what additional documentation might be
+helpful in this [discussion
+thread](https://github.com/uswds/uswds/discussions/6477).

--- a/src/components/usa-banner/usa-banner.css
+++ b/src/components/usa-banner/usa-banner.css
@@ -163,7 +163,7 @@ header,
   flex-wrap: nowrap;
   margin-inline: auto;
   max-width: var(--usa-banner-max-width);
-  padding-inline-end: 0;
+  padding-inline-end: var(--usa-spacing-05);
   padding-inline-start: var(--usa-spacing-2);
 }
 


### PR DESCRIPTION
## Summary

Implemented custom theming options for the `usa-banner` component, including font family adjustments, and refined its documentation for clarity and consistency.

Closes #194 

[Preview link](https://federalist-ab6c0bdb-eccd-4b26-bb5f-b0154661e999.sites.pages.cloud.gov/preview/uswds/uswds-elements/eg/194-banner-custom-theme-example/?path=/story/components-banner--custom-theme-example)  

The `usa-banner` component lacked a clear example demonstrating how to apply custom styling through CSS variables.

This PR introduces a `CustomThemeExample` story in `banner.stories.js` to showcase how users can customize the banner's appearance using CSS variables. It updates the `usa-banner-font-family` to a monospace font stack to illustrate how fonts can be changed. Furthermore, it refactors the `docs.mdx` file by removing unnecessary `<p className="site-note">` wrappers, ensuring that "Note" sections render consistently as bold text and updating the discussion thread link format. A minor CSS adjustment was also made to `padding-inline-end` for better spacing control.

*   Added a `CustomThemeExample` story to `banner.stories.js` to demonstrate custom theming via CSS variables.
*   Refactored `docs.mdx` by removing `<p className="site-note">` wrappers around "Note" sections and updated the discussion thread link format.
*   Adjusted the `padding-inline-end` property in `usa-banner.css`.
*   Renamed the `ToggleBanner` story to `ToggleBannerTest` and disabled its documentation so it no longer appears on the "Docs" page.

Steps for testing:
1.  Verify that the `CustomThemeExample` story correctly applies the custom themes in Storybook.
