### PR TITLE
Web components: install plugin for storybook tags

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,6 +8,7 @@ const config = {
     "@storybook/addon-links",
     "@storybook/addon-docs",
     "@storybook/addon-a11y",
+    "storybook-addon-tag-badges",
   ],
   framework: {
     name: "@storybook/web-components-vite",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "serve-static": "^2.2.0",
         "shadow-dom-testing-library": "^1.11.3",
         "storybook": "^9.0.18",
+        "storybook-addon-tag-badges": "^2.0.3",
         "style-dictionary": "^5.0.1",
         "stylelint": "^16.24.0",
         "stylelint-config-standard": "^39.0.0",
@@ -12618,6 +12619,22 @@
         "prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/storybook-addon-tag-badges": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/storybook-addon-tag-badges/-/storybook-addon-tag-badges-2.0.3.tgz",
+      "integrity": "sha512-b9zCPAQvDlJochvqUah+tJWuQpQIeCILNdwbO3XqvFFM+hBe60vCD6oVutI031abBru8w/8BCBzJiYtgA25r1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/icons": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "storybook": "^9.0.0"
       }
     },
     "node_modules/storybook/node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "serve-static": "^2.2.0",
     "shadow-dom-testing-library": "^1.11.3",
     "storybook": "^9.0.18",
+    "storybook-addon-tag-badges": "^2.0.3",
     "style-dictionary": "^5.0.1",
     "stylelint": "^16.24.0",
     "stylelint-config-standard": "^39.0.0",

--- a/src/components/usa-banner/banner.stories.js
+++ b/src/components/usa-banner/banner.stories.js
@@ -30,6 +30,7 @@ const filteredArgTypes = (argTypes) => {
 export default {
   title: "Components/Banner",
   component: "usa-banner",
+  tags: ["beta"],
   args: {
     ...args,
     label: "",


### PR DESCRIPTION
**Note:** This was originally submitted by @caseywatts in #186. Unfortunately, the required workflow for code scanning does not seem to run when PRs are opened from a fork of the repository due to a permissions issue. This is his work that I'm re-adding to be able to fire off the required workflows.

## Summary

Our Storybook now displays a badge to indicate the state of a component (e.g. "beta").

## Related issue

Closes #185 


## Preview link

Preview link:

<!-- If available, provide a link to a demo of the solution in action. -->

Screenshot of the badge:
<img width="1916" height="921" alt="image" src="https://github.com/user-attachments/assets/fe8a594b-735d-4b32-9c6b-de758a0f8e35" />


## Problem statement

We want to be able to tag components with their state ("experimental" vs "stable", etc). Currently there is only one component, usa-banner, which I believe is experimental still. When we get additional components in, it will be helpful to be able to distinguish between them.

I'd like to add [an experimental version of usa-alert sometime](https://gist.github.com/caseywatts/553d5feaf5e3d8057f8360b7990d7b1d), after I re-format it to match the updated USWDS Elements standards. Before getting that work in, it will help us to set this up, so we will be able to clearly tag that component as "experimental".

## Solution

This PR uses the storybook-suggested pattern of using [storybook tags](https://storybook.js.org/blog/storybook-tags/) to generate [badges](https://storybook.js.org/blog/storybook-tags/).

A month or two ago I heard from Matt Henry and Anne Petersen that an "experimental" tag was being strongly considered. This seems like the most natural implementation of that, at least in our Storybook.

We may want to discuss what tag/badge names to use specifically.
* Is "experimental" the right tag/badge name for us? (I think it's a solid choice!)
* Do we want "stable" components to have no badge, or a "stable" badge? (Someday when most of our components are stable, I think no badge makes the most sense -- less visual clutter.)

## Testing and review

1. Run `npm run storybook`
2. See the "experimental" label on usa-banner

## Dependency updates

| Dependency name              | Previous version | New version |
| :---------------------------- | :--------------: | :---------: |
| storybook-addon-tag-badges     |        --        |    2.0.3   |