### PR TITLE
Web components: expose style tokens as a build artifact

### DIFF
--- a/.changeset/petite-dodos-call.md
+++ b/.changeset/petite-dodos-call.md
@@ -1,0 +1,5 @@
+---
+"@uswds/elements": patch
+---
+
+Add style tokens to package output

--- a/build/css/breakpoints.css
+++ b/build/css/breakpoints.css
@@ -3,11 +3,11 @@
  */
 
 :root {
-  --usa-breakpoint-tablet: 40rem;
   --usa-breakpoint-card: 10rem;
   --usa-breakpoint-card-lg: 15rem;
   --usa-breakpoint-mobile: 20rem;
   --usa-breakpoint-mobile-lg: 30rem;
+  --usa-breakpoint-tablet: 40rem;
   --usa-breakpoint-tablet-lg: 55rem;
   --usa-breakpoint-desktop: 64rem;
   --usa-breakpoint-desktop-lg: 75rem;

--- a/build/scss/_breakpoints.scss
+++ b/build/scss/_breakpoints.scss
@@ -1,11 +1,11 @@
 
 // Do not edit directly, this file was auto-generated.
 
-$usa-breakpoint-tablet: 40rem;
 $usa-breakpoint-card: 10rem;
 $usa-breakpoint-card-lg: 15rem;
 $usa-breakpoint-mobile: 20rem;
 $usa-breakpoint-mobile-lg: 30rem;
+$usa-breakpoint-tablet: 40rem;
 $usa-breakpoint-tablet-lg: 55rem;
 $usa-breakpoint-desktop: 64rem;
 $usa-breakpoint-desktop-lg: 75rem;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     ".storybook",
     "storybook",
     "internals/scripts",
+    "build",
     "dist",
     "src"
   ],
@@ -17,7 +18,8 @@
     },
     "./components/*": "./dist/components/*.js",
     "./src/components/*": "./src/components/*/index.js",
-    "./core/*": "./src/core/*"
+    "./core/*": "./src/core/*",
+    "./styles/*": "./build/*"
   },
   "scripts": {
     "build": "tsc -p ./config/tsconfig.json && vite build --config ./config/vite.config.ts && npm run manifest:build",

--- a/tokens/dimension/breakpoints.json
+++ b/tokens/dimension/breakpoints.json
@@ -1,8 +1,5 @@
 {
   "breakpoint": {
-    "tablet": {
-      "$value": { "value": "40", "unit": "rem" }
-    },
     "card": {
       "$value": { "value": "10", "unit": "rem" }
     },
@@ -14,6 +11,9 @@
     },
     "mobile-lg": {
       "$value": { "value": "30", "unit": "rem" }
+    },
+    "tablet": {
+      "$value": { "value": "40", "unit": "rem" }
     },
     "tablet-lg": {
       "$value": { "value": "55", "unit": "rem" }


### PR DESCRIPTION
## Summary

This update improves consistency in breakpoint definitions and allows consumers to directly access generated style tokens. Breakpoint definitions were reordered to align with a more logical sequence, and the build directory containing generated CSS and SCSS tokens is now included in the package exports.


Closes #208 

Preview link: N/A

The generated style artifacts in the `build` directory were not exposed through the `package.json` exports. Remaining in the requires consumers of the library to manually locate or copy style files, leading to less efficient workflows.

This PR modifies `package.json` to include the `build` directory in the published package and exposes the contents of `build` via the `./styles/*`. This approach was chosen because exposing the `build` directory and its contents via `exports` is the standard and most direct way to make these generated assets available to package consumers. 

*   Added `build` directory to the `files` array in `package.json` to ensure it's included in the published package.
*   Added `"./styles/*": "./build/*"` export mapping to `package.json` to allow direct access to generated style tokens from the `build` directory.


To review this change:
1.  Inspect `package.json`: Confirm that the `files` array includes "build" and that the `"./styles/*": "./build/*"` export mapping is present.
2.  (Optional) To confirm package output, run `npm publish --dry-run` locally and ensure the `build` directory is listed in the console output.
