### PR TITLE
Web components: Add `contents: read` permissions to GitHub workflows and enable trusted publishing for NPM

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,5 +1,8 @@
 name: Code formatting
+permissions:
+  contents: read
 on: push
+
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: '' # setting this to an empty string makes changesets use trusted publishing: https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -1,4 +1,6 @@
 name: Storybook and Component Tests
+permissions:
+  contents: read
 on: push
 jobs:
   test:


### PR DESCRIPTION
# Summary

Added `contents: read` permissions to `formatting.yml` and `ui-test.yml` GitHub workflows to comply with default permissions. Enabled trusted publishing for NPM releases by setting `NPM_TOKEN` to an empty string in `release.yml`.

Closes #210

Preview link: N/A

The desired state is that GitHub Actions workflows have appropriate permissions to access repository content and NPM packages are published securely using trusted publishing.

Currently, the `formatting.yml` and `ui-test.yml` workflows have issues flagged in the security scan. Additionally, the `release.yml` workflow was not leveraging trusted publishing for NPM, which is a more secure way to publish packages.

This PR addresses the problem by explicitly adding `permissions: contents: read` to both the `formatting.yml` and `ui-test.yml` workflows. This ensures that these workflows have the necessary permissions to check out the repository content. For the `release.yml` workflow, the `NPM_TOKEN` environment variable is set to an empty string. This approach is recommended by the `changesets` project (as linked in the commit) to enable trusted publishing, providing a more secure mechanism for package distribution without relying on a stored NPM token.

*   Added `permissions: contents: read` to `.github/workflows/formatting.yml`.
*   Added `permissions: contents: read` to `.github/workflows/ui-test.yml`.
*   Modified `.github/workflows/release.yml` to set `NPM_TOKEN: ''` to enable trusted publishing.
