### PR TITLE
Web components: Enhance release workflow for OIDC and add repository metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release and publish to NPM
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   id-token: write
 
@@ -33,7 +33,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # pin@v1.5.3
         with:
           publish: npm run release
-          commitMode: github-api
+          commitMode: github-api # the api is required to get signed commits on changeset bot's workflow
           branch: develop
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0
+          NPM_TOKEN: "" # Workaround. See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: Release and publish to NPM
 permissions:
   contents: write
-  pull-requests: write
   id-token: write
+  pull-requests: write
 
 on:
   push:
+    branches:
+      - develop
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -38,4 +40,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0
-          NPM_TOKEN: '' # Workaround. See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
+          NPM_TOKEN: '' # setting this to an empty string makes changesets use trusted publishing: https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release and publish to NPM
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
+  id-token: write
 
 on:
   push:
@@ -37,4 +38,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0
-          NPM_TOKEN: "" # Workaround. See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
+          NPM_TOKEN: '' # Workaround. See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ permissions:
 
 on:
   push:
-    branches:
-      - main
-      - develop
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -40,4 +37,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0
-          NPM_TOKEN: '' # setting this to an empty string makes changesets use trusted publishing: https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0-alpha.3",
   "type": "module",
   "customElements": "custom-elements.json",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/uswds/uswds-elements.git"
+  },
   "files": [
     ".storybook",
     "storybook",


### PR DESCRIPTION
## Summary

The release workflow has been updated to support OpenID Connect (OIDC) for secure publishing to NPM, and the project's repository URL has been added to `package.json` for better package metadata.

Closes #219 

Preview link: N/A

The npm registry is deprecating classic tokens in favor of [trusted publishing](https://docs.npmjs.com/trusted-publishers). This pull request addresses the need for a more secure and robust publishing process to NPM, leveraging OpenID Connect (OIDC) to eliminate the need for token-based authentication and associated overhead that comes with managing and rotating them. 

The solution involves modifying the GitHub Actions release workflow to enable `id-token: write` permissions, allowing the `changesets/action` to utilize trusted publishing. This enhances security by using ephemeral OIDC tokens for authentication. Additionally, the `repository` field has been added to `package.json`, providing a direct link to the project's source code on GitHub, which is required by the trusted publishing workflow.

*   Updated `.github/workflows/release.yml` to include `id-token: write` permission and clarified the comment regarding `NPM_TOKEN` for trusted publishing.
*   Added the `repository` field to `package.json` with the project's GitHub URL.
*   Explicitly defined `on: push: branches: - develop` in `release.yml` to trigger the release process only on the `develop` branch.

To review these changes, please:
1.  Verify the changes in `.github/workflows/release.yml` correctly reflect the `permissions` and `on: push: branches` configurations.
2.  Confirm the `repository` field is accurately added to `package.json`.
3.  After this PR is merged to `develop`, observe the next release workflow run to ensure it successfully publishes to NPM using OIDC (i.e., without requiring an explicit `NPM_TOKEN` environment variable).