### PR TITLE
Web components: Make documentation adhere to style guide

### DIFF
--- a/.changeset/good-needles-fix.md
+++ b/.changeset/good-needles-fix.md
@@ -1,0 +1,8 @@
+---
+"@uswds/elements": patch
+---
+
+- Add documentaton
+- Export types for various front-end frameworks
+- Add component registration helper with collision checking for custom elements
+- Provide React wrapper for web component implementation

--- a/examples/with-astro/package.json
+++ b/examples/with-astro/package.json
@@ -9,7 +9,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@uswds/elements": "1.0.0-alpha.4",
+    "@uswds/elements": "1.0.0-alpha.5",
     "astro": "^5.16.0"
   }
 }

--- a/examples/with-react/package.json
+++ b/examples/with-react/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@uswds/elements": "1.0.0-alpha.4",
+    "@uswds/elements": "1.0.0-alpha.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/examples/with-solid/package.json
+++ b/examples/with-solid/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@uswds/elements": "1.0.0-alpha.4",
+    "@uswds/elements": "1.0.0-alpha.5",
     "solid-js": "^1.9.10"
   },
   "devDependencies": {

--- a/examples/with-vue/package.json
+++ b/examples/with-vue/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@uswds/elements": "1.0.0-alpha.4",
+    "@uswds/elements": "1.0.0-alpha.5",
     "vue": "^3.5.24"
   },
   "devDependencies": {

--- a/storybook/framework-guidance.mdx
+++ b/storybook/framework-guidance.mdx
@@ -11,7 +11,7 @@ import VueExample from "../examples/with-vue/src/App.vue?raw";
 
 # Framework-specific Guidance
 
-We have made every effort to make using USWDS Elements in your project as easy as possible. Since many projects use modern front-end libraries and frameworks, we have included an example directory in this repository that shows minimal examples of how to import and use USWDS Elements with a variety of popular front-end technologies. The goal is to provide an experience that involves minimal configuration to get up and running with your framework or library of choice.
+We've made every effort to make using USWDS Elements in your project as easy as possible. Since many projects use modern front-end libraries and frameworks, we've included an [examples directory](https://github.com/uswds/uswds-elements/tree/develop/examples) in this repository that shows how to import and use USWDS Elements with a variety of popular front-end technologies. The goal is to provide an experience that involves minimal configuration to get up and running with your framework or library of choice.
 
 In all cases, install the project from the npm package registry.
 
@@ -23,7 +23,7 @@ $ npm install @uswds/elements
 
 ### HTML
 
-To use a specific element directly in an HTML page, use the code snippet below. This example also applies if you are using USWDS Elements in a CMS that has its own templating engine (e.g. Drupal, WordPress, etc.).
+To use a specific element directly in an HTML page, use the code snippet below. This example also applies if you're using USWDS Elements in a CMS that has its own templating engine (e.g. Drupal, WordPress, etc.).
 
 ```html
 <!-- importing directly into an HTML page -->
@@ -53,7 +53,7 @@ This is a minimal example of implementation in [SolidJS](https://www.solidjs.com
 
 #### TypeScript support
 
-If you are using TypeScript for your SolidJS project, add a `custom-elements.d.ts` file to `src/` directory.
+If you're using TypeScript for your SolidJS project, add a `custom-elements.d.ts` file to `src/` directory.
 
 <Source code={SolidDTsExample} language="ts" />
 
@@ -73,7 +73,7 @@ This is a minimal example of implementation in [Vue](https://vuejs.org/).
 
 <Source code={VueExample} language="vue" />
 
-Additionally, your build tool needs to know about the custom elements so they are not parsed at build time. This is how you do it in Vite:
+Additionally, your build tool needs to know about the custom elements so they aren't parsed at build time. This is how you do it in Vite:
 
 ```
 // vite.config.ts


### PR DESCRIPTION
## Summary

Closes #231

Preview link: https://federalist-ab6c0bdb-eccd-4b26-bb5f-b0154661e999.sites.pages.cloud.gov/preview/uswds/uswds-elements/eg/231-update-documentation/

The documentation within `storybook/framework-guidance.mdx` did not consistently adhere to a concise style, specifically regarding the use of contractions. Additionally, the initial mention of the "examples directory" lacked a direct link, making it less convenient for users to navigate directly to the examples. 

This PR addresses the identified documentation style issues by consistently applying contractions such as "We've", "you're", and "aren't" throughout the `framework-guidance.mdx` file. Furthermore, a direct link to the [examples directory](https://github.com/uswds/uswds-elements/tree/develop/examples) has been added to improve accessibility and user navigation. This approach was chosen to enhance the overall readability and user-friendliness of the documentation, making it more concise and directly actionable.

*   Applied contractions in the "Framework-specific Guidance".

**Upon merging, this will trigger the workflow to publish the alpha 5 release of the elements project to the NPM registry**