### PR TITLE
USWDS Elements - `usa-banner`: Make path to flag icon a prop

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -100,6 +100,16 @@
           "members": [
             {
               "kind": "field",
+              "name": "flagSrc",
+              "privacy": "public",
+              "type": {
+                "text": "string"
+              },
+              "default": "usFlagSmall",
+              "attribute": "flagSrc"
+            },
+            {
+              "kind": "field",
               "name": "lang",
               "privacy": "public",
               "type": {
@@ -215,6 +225,15 @@
               "propName": "tld"
             },
             {
+              "name": "flagSrc",
+              "type": {
+                "text": "string"
+              },
+              "default": "usFlagSmall",
+              "fieldName": "flagSrc",
+              "propName": "flagsrc"
+            },
+            {
               "name": "isOpen",
               "type": {
                 "text": "boolean"
@@ -237,14 +256,6 @@
         {
           "kind": "js",
           "name": "UsaBanner",
-          "declaration": {
-            "name": "UsaBanner",
-            "module": "src/components/usa-banner/index.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "usa-banner",
           "declaration": {
             "name": "UsaBanner",
             "module": "src/components/usa-banner/index.ts"
@@ -347,14 +358,6 @@
         {
           "kind": "js",
           "name": "UsaLink",
-          "declaration": {
-            "name": "UsaLink",
-            "module": "src/components/usa-link/index.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "usa-link",
           "declaration": {
             "name": "UsaLink",
             "module": "src/components/usa-link/index.ts"

--- a/src/components/usa-banner/index.ts
+++ b/src/components/usa-banner/index.ts
@@ -112,6 +112,7 @@ const USA_BANNER_TRANSLATIONS: Record<
  */
 export class UsaBanner extends LitElement {
   static properties = {
+    flagSrc: { type: String },
     lang: { type: String, reflect: true },
     isOpen: { state: true },
     label: { type: String },
@@ -119,6 +120,7 @@ export class UsaBanner extends LitElement {
   };
 
   // Property declarations
+  flagSrc!: string;
   lang!: "en" | "es";
   isOpen!: boolean;
   label!: string;
@@ -134,6 +136,7 @@ export class UsaBanner extends LitElement {
 
   constructor() {
     super();
+    this.flagSrc = usFlagSmall;
     this.lang = "en";
     this.isOpen = false;
     this.tld = "gov";
@@ -230,7 +233,7 @@ export class UsaBanner extends LitElement {
                 <img
                   aria-hidden="true"
                   class="header-flag"
-                  src=${usFlagSmall}
+                  src=${this.flagSrc}
                   alt=""
                 />
               </div>


### PR DESCRIPTION
# Summary

This PR adds a prop to the banner component to allow customization of the flag image.

## Preview

<img width="435" height="47" alt="image" src="https://github.com/user-attachments/assets/ed1a0d19-f512-46e2-9ff7-8368d98da90b" />

## Problem statement

As it is, the banner component works great and offers a lot of customization options, but having the image src for the flag icon hard-coded limits its utility outside of the federal .gov space. This small change makes the component useful to a lot more groups.

## Testing and review

If you want to test it locally, here's a flag svg that you can swap out for the US flag:
![md_flag](https://github.com/user-attachments/assets/104637c4-d43a-482a-8535-4d5648b559fb)