### PR TITLE
Pin workflow actions versions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: Install node.js version
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # pin v6.3.0
       id: install-node
       with:
         node-version-file: '.nvmrc'

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
 
       - name: Setup project
         uses: ./.github/actions/setup

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       HOME: /root
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
 
       - name: Setup project
         uses: ./.github/actions/setup
@@ -29,7 +29,7 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test --config=./config/playwright.config.ts
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # pin v7.0.0
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
 
       - name: Setup project
         uses: ./.github/actions/setup
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # pin@v1.5.3
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # pin v1.5.3
         with:
           publish: npm run release
           commitMode: github-api # the api is required to get signed commits on changeset bot's workflow

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
 
       - name: Setup project
         uses: ./.github/actions/setup

--- a/.github/workflows/update-playwright-snapshots.yml
+++ b/.github/workflows/update-playwright-snapshots.yml
@@ -19,7 +19,7 @@ jobs:
       HOME: /root
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
         with:
           ref: ${{ github.event.inputs.branch }}
 
@@ -33,7 +33,7 @@ jobs:
         run: npx playwright test --config=./config/playwright.config.ts --update-snapshots
 
       - name: Upload new screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # pin v7.0.0
         with:
           name: playwright-snapshots
           path: e2e/**/*-snapshots/

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ If you have questions about changing the pre-release tag or the release automati
 
 ## Component versions
 
-| Component    | Status    |
-| ------------ | --------- |
-| `usa-banner` | Beta (Banner only, not entire package)     |
+| Component    | Status                                                                       |
+| ------------ | ---------------------------------------------------------------------------- |
+| `usa-banner` | Beta (Banner only, not entire package)                                       |
 | `usa-link`   | Pre-alpha (proof-of-concept: not intended as direction, or even for release) |


### PR DESCRIPTION
## Summary

Pinned specific SHA versions for the GitHub Actions used in the CI workflows to tighten security posture. Also addressed a minor formatting issue in the `README.md` that was causing one of the workflows to fail.

## Related issue

[#6601](https://github.com/uswds/uswds/issues/6601)

## Problem statement

Workflow actions throughout the `.github/*` directory used mutable tags (`@v2`, `@v1`). The more secure option is to pin these to specific commit hashes so we know exactly which version is running.

## Solution

Pinned each GitHub Action to a specific commit SHA in all workflow files:
- actions/setup-node pinned to 53b83947a5a98c8d113130e565377fae1a50d02f (v6.3.0)
- actions/checkout pinned to de0fac2e4500dabe0009e67214ff5f5447ce83dd (v6.0.2)
- actions/upload-artifact pinned to bbbca2ddaa5d8feaa63e36b76fdaad77386f024f (v7.0.0)

This ensures the workflow uses known versions of the actions, providing stability and predictability for future runs.
