### PR TITLE
Update dependencies flagged by Snyk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "jsdom": "^27.2.0",
         "lightningcss": "^1.30.2",
         "prettier": "^3.6.2",
-        "sass": "^1.94.0",
+        "sass": "^1.99.0",
         "serve-static": "^2.2.0",
         "shadow-dom-testing-library": "^1.13.1",
         "storybook": "^10.2.13",
@@ -63,7 +63,7 @@
         "web-vitals": "^5.1.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.53.2"
+        "@rollup/rollup-linux-x64-gnu": "^4.60.4"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -4383,9 +4383,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
       "cpu": [
         "x64"
       ],
@@ -14898,6 +14898,20 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -15010,14 +15024,14 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.94.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.94.0.tgz",
-      "integrity": "sha512-Dqh7SiYcaFtdv5Wvku6QgS5IGPm281L+ZtVD1U2FJa7Q0EFRlq8Z3sjYtz6gYObsYThUOz9ArwFqPZx+1azILQ==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+      "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "jsdom": "^27.2.0",
     "lightningcss": "^1.30.2",
     "prettier": "^3.6.2",
-    "sass": "^1.94.0",
+    "sass": "^1.99.0",
     "serve-static": "^2.2.0",
     "shadow-dom-testing-library": "^1.13.1",
     "storybook": "^10.2.13",
@@ -113,6 +113,6 @@
     "web-vitals": "^5.1.0"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.53.2"
+    "@rollup/rollup-linux-x64-gnu": "^4.60.4"
   }
 }


### PR DESCRIPTION
# Summary

Snyk had previously flagged 2 dependencies (`@rollup/rollup-linux-x64-gnu` and `sass`) but its PR was unsigned. This replaces https://github.com/uswds/uswds-elements/pull/252 and https://github.com/uswds/uswds-elements/pull/251

## Dependency updates

| Dependency name                  | Previous version | New version |
| :---------------------------- | :---------------: | :-----------: |
| @rollup/rollup-linux-x64-gnu |     ^4.53.2             |   ^4.60.4     |
| sass                                           |     ^1.94.0           |   ^1.99.0       |

